### PR TITLE
Pin goreleaser to version 1 for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5.0.0
         with:
-          version: latest
+          version: '~> v1'
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
When trying to do release of v0.1.1 got an error:

```
 • only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
  ⨯ command failed                                   error=only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
```

For now going to pin goreleaser to v1 and then eventually it will be upgraded