### PR TITLE
Improve Makefile OS_ARCH variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ NAMESPACE=openvpn
 NAME=cloudconnexa
 VERSION=0.0.12
 BINARY=terraform-provider-${NAME}
-OS_ARCH=darwin_arm64
+OS_ARCH=$(shell go env GOHOSTOS)_$(shell go env GOHOSTARCH)
 
 default: install
 


### PR DESCRIPTION
Currently in Makefile we have next line:
```
OS_ARCH=darwin_arm64
```
When i need to make some changes to provider or to test some code i need to run "make" command. But for it to build proper version for me, i need to put manually "linux_amd64" in Makefile and doing this manually repeatedly seems like not the good idea.

Therefore i propose to change this line to:
```
OS_ARCH=$(shell go env GOHOSTOS)_$(shell go env GOHOSTARCH)
```

$(shell go env GOHOSTOS) retrieves the operating system of the host machine.
$(shell go env GOHOSTARCH) retrieves the architecture of the host machine.

The combination `$(shell go env GOHOSTOS)_$(shell go env GOHOSTARCH)` produces a string like darwin_arm64, linux_amd64, etc.

This reduces the need for manual update of Makefile.