### PR TITLE
Fixed: [TF] data source "cloudconnexa_user" not working properly

### DIFF
--- a/cloudconnexa/data_source_user.go
+++ b/cloudconnexa/data_source_user.go
@@ -28,7 +28,7 @@ func dataSourceUser() *schema.Resource {
 			},
 			"role": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Computed:    true,
 				Description: "The type of user role. Valid values are `ADMIN`, `MEMBER`, or `OWNER`.",
 			},
 			"email": {
@@ -103,7 +103,7 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, m interface
 	c := m.(*cloudconnexa.Client)
 	var diags diag.Diagnostics
 	userName := d.Get("username").(string)
-	user, err := c.Users.Get(userName)
+	user, err := c.Users.GetByUsername(userName)
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gruntwork-io/terratest v0.46.1
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
-	github.com/openvpn/cloudconnexa-go-client/v2 v2.0.8
+	github.com/openvpn/cloudconnexa-go-client/v2 v2.0.10
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -485,8 +485,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/openvpn/cloudconnexa-go-client/v2 v2.0.8 h1:67NXu2WqNnE05fhrq1HXbQKFMidhnd7ts6SFeuZSkLo=
-github.com/openvpn/cloudconnexa-go-client/v2 v2.0.8/go.mod h1:udq5IDkgXvMO6mQUEFsLHzEyGGAduhO0jJvlb9f4JkE=
+github.com/openvpn/cloudconnexa-go-client/v2 v2.0.10 h1:k5wx9syxxwNNKbfEQkVjb/4hjhBrhbgBDmeT72yNe3w=
+github.com/openvpn/cloudconnexa-go-client/v2 v2.0.10/go.mod h1:udq5IDkgXvMO6mQUEFsLHzEyGGAduhO0jJvlb9f4JkE=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Issue:

In terraform there is concept of “data source”, it is used usually like this: we know that in the some cloud provider there is a resource, and we know it’s name and we want to use this resource, by it’s name, as references:

```
data "cloudconnexa_network" "name" {
  name = "sasa"
}

output "cloudconnexa_network" {
  value = data.cloudconnexa_network.name
}
```



```
data "cloudconnexa_user_group" "name" {
  name = "xxx"
}
output "cloudconnexa_user_group" {
  value = data.cloudconnexa_user_group.name
}
```

But for next code below it gives an error:

```
data "cloudconnexa_user" "name" {
  username = "sa12121"
}
```

![CleanShot 2024-07-26 at 13 41 54@2x](https://github.com/user-attachments/assets/17241d71-40f3-40c2-afa9-4de9580a1d42)


data "cloudconnexa_user" should only require 1 filed = “username”.
