### PR TITLE
Fix cloudconnexa_vpn_region data source

### DIFF
--- a/cloudconnexa/data_source_vpn_region.go
+++ b/cloudconnexa/data_source_vpn_region.go
@@ -2,6 +2,7 @@ package cloudconnexa
 
 import (
 	"context"
+
 	"github.com/openvpn/cloudconnexa-go-client/v2/cloudconnexa"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -45,7 +46,7 @@ func dataSourceVpnRegion() *schema.Resource {
 func dataSourceVpnRegionRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*cloudconnexa.Client)
 	var diags diag.Diagnostics
-	vpnRegionId := d.Get("region_id").(string)
+	vpnRegionId := d.Get("id").(string)
 	vpnRegion, err := c.VPNRegions.GetVpnRegion(vpnRegionId)
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)


### PR DESCRIPTION
We changed data source to expect "id" field:
```
data "cloudconnexa_vpn_region" "name" {
  id = "us-west-1"
}

output "name" {
  value = data.cloudconnexa_vpn_region.name
}
```
but forgot to update it in code and it was crashing provider. Now all good