### PR TITLE
Update cloudconnexa_user resource

### DIFF
--- a/cloudconnexa/resource_user.go
+++ b/cloudconnexa/resource_user.go
@@ -29,20 +29,20 @@ func resourceUser() *schema.Resource {
 			},
 			"email": {
 				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 120),
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 120),
 				Description:  "An invitation to CloudConnexa account will be sent to this email. It will include an initial password and a VPN setup guide.",
 			},
 			"first_name": {
 				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 20),
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 20),
 				Description:  "User's first name.",
 			},
 			"last_name": {
 				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 20),
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 20),
 				Description:  "User's last name.",
 			},
 			"group_id": {

--- a/cloudconnexa/resource_user.go
+++ b/cloudconnexa/resource_user.go
@@ -132,11 +132,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, m interface
 		return append(diags, diag.FromErr(err)...)
 	}
 	d.SetId(user.Id)
-	return append(diags, diag.Diagnostic{
-		Severity: diag.Warning,
-		Summary:  "The user's role cannot be changed using the code.",
-		Detail:   "There is a bug in CloudConnexa API that prevents setting the user's role during the creation. All users are created as Members by default. Once it's fixed, the provider will be updated accordingly.",
-	})
+	return diags
 }
 
 func resourceUserRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/cloudconnexa/resource_user.go
+++ b/cloudconnexa/resource_user.go
@@ -2,6 +2,7 @@ package cloudconnexa
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -28,19 +29,19 @@ func resourceUser() *schema.Resource {
 			},
 			"email": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 120),
 				Description:  "An invitation to CloudConnexa account will be sent to this email. It will include an initial password and a VPN setup guide.",
 			},
 			"first_name": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 20),
 				Description:  "User's first name.",
 			},
 			"last_name": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 20),
 				Description:  "User's last name.",
 			},
@@ -53,7 +54,6 @@ func resourceUser() *schema.Resource {
 			"role": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Default:     "MEMBER",
 				Description: "The type of user role. Valid values are `ADMIN`, `MEMBER`, or `OWNER`.",
 			},

--- a/cloudconnexa/resource_user.go
+++ b/cloudconnexa/resource_user.go
@@ -161,7 +161,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, m interface{}
 func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*cloudconnexa.Client)
 	var diags diag.Diagnostics
-	if !d.HasChanges("first_name", "last_name", "group_id", "email") {
+	if !d.HasChanges("first_name", "last_name", "group_id", "email", "role") {
 		return diags
 	}
 
@@ -174,8 +174,8 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m interface
 	_, firstName := d.GetChange("first_name")
 	_, lastName := d.GetChange("last_name")
 	_, role := d.GetChange("role")
-	status := u.Status
 	_, groupId := d.GetChange("group_id")
+	status := u.Status
 
 	err = c.Users.Update(cloudconnexa.User{
 		Id:        d.Id(),
@@ -187,7 +187,11 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m interface
 		Status:    status,
 	})
 
-	return append(diags, diag.FromErr(err)...)
+	if err != nil {
+		return append(diags, diag.FromErr(err)...)
+	}
+
+	return diags
 }
 
 func resourceUserDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/cloudconnexa/resource_user.go
+++ b/cloudconnexa/resource_user.go
@@ -30,19 +30,19 @@ func resourceUser() *schema.Resource {
 			"email": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 120),
+				ValidateFunc: validation.StringLenBetween(0, 120),
 				Description:  "An invitation to CloudConnexa account will be sent to this email. It will include an initial password and a VPN setup guide.",
 			},
 			"first_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 20),
+				ValidateFunc: validation.StringLenBetween(0, 20),
 				Description:  "User's first name.",
 			},
 			"last_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(1, 20),
+				ValidateFunc: validation.StringLenBetween(0, 20),
 				Description:  "User's last name.",
 			},
 			"group_id": {

--- a/cloudconnexa/resource_user.go
+++ b/cloudconnexa/resource_user.go
@@ -29,19 +29,19 @@ func resourceUser() *schema.Resource {
 			},
 			"email": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 120),
 				Description:  "An invitation to CloudConnexa account will be sent to this email. It will include an initial password and a VPN setup guide.",
 			},
 			"first_name": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 20),
 				Description:  "User's first name.",
 			},
 			"last_name": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 20),
 				Description:  "User's last name.",
 			},

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gruntwork-io/terratest v0.47.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
-	github.com/openvpn/cloudconnexa-go-client/v2 v2.0.12
+	github.com/openvpn/cloudconnexa-go-client/v2 v2.0.13
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -485,8 +485,6 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/openvpn/cloudconnexa-go-client/v2 v2.0.12 h1:qUgOw8ppxtUj741XqfVCbtSNHBM81J6cEQkr3hgs9Jg=
-github.com/openvpn/cloudconnexa-go-client/v2 v2.0.12/go.mod h1:udq5IDkgXvMO6mQUEFsLHzEyGGAduhO0jJvlb9f4JkE=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -485,6 +485,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
+github.com/openvpn/cloudconnexa-go-client/v2 v2.0.13 h1:Bm47oT/O+CwXdwUu84NZZXETZCo/9Th3Cx+EGUXvyPU=
+github.com/openvpn/cloudconnexa-go-client/v2 v2.0.13/go.mod h1:udq5IDkgXvMO6mQUEFsLHzEyGGAduhO0jJvlb9f4JkE=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Removed "ForceNew" from "role" field for "cloudconnexa_user" resource.
Also removed warning:
```
 Warning: The user's role cannot be changed using the code.
│ 
│   with cloudconnexa_user.this,
│   on main.tf line 1, in resource "cloudconnexa_user" "this":
│    1: resource "cloudconnexa_user" "this" {
│ 
│ There is a bug in CloudConnexa API that prevents setting the user's role during the creation. All users are created as Members by default. Once it's fixed, the provider will be updated
│ accordingly.
╵
```

I tried to create new user like this with ADMIN role and it worked:
```
resource "cloudconnexa_user_group" "this" {
  name           = "test-group"
  vpn_region_ids = ["eu-central-1"]
  connect_auth   = "AUTH"
}


resource "cloudconnexa_user" "name" {
  username   = "trolololo"
  group_id   = cloudconnexa_user_group.this.id
  email      = "xxxx@xxxx.xxx" # replace with valid email
  first_name = "BBBBBBBBBBBBBB"
  last_name  = "CCCCCCCCCCCCC"
  role       = "ADMIN"
}

```