### PR TITLE
[Security Fix] Enhance data source and resource connectors

### DIFF
--- a/cloudconnexa/data_source_host_connector.go
+++ b/cloudconnexa/data_source_host_connector.go
@@ -53,11 +53,13 @@ func dataSourceHostConnector() *schema.Resource {
 			"profile": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 				Description: "OpenVPN profile",
 			},
 			"token": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 				Description: "Connector token",
 			},
 		},

--- a/cloudconnexa/data_source_network_connector.go
+++ b/cloudconnexa/data_source_network_connector.go
@@ -53,11 +53,13 @@ func dataSourceNetworkConnector() *schema.Resource {
 			"profile": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 				Description: "OpenVPN profile",
 			},
 			"token": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 				Description: "Connector token",
 			},
 		},

--- a/cloudconnexa/resource_host_connector.go
+++ b/cloudconnexa/resource_host_connector.go
@@ -59,11 +59,13 @@ func resourceHostConnector() *schema.Resource {
 			"profile": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 				Description: "OpenVPN profile of the connector.",
 			},
 			"token": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 				Description: "Connector token.",
 			},
 		},

--- a/cloudconnexa/resource_network_connector.go
+++ b/cloudconnexa/resource_network_connector.go
@@ -58,11 +58,13 @@ func resourceNetworkConnector() *schema.Resource {
 			"profile": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 				Description: "OpenVPN profile of the connector.",
 			},
 			"token": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 				Description: "Connector token.",
 			},
 		},


### PR DESCRIPTION
Mark connector profile and token fields as sensitive

Prevents private keys from being exposed in Terraform plans by adding `Sensitive: true` to profile and token fields in all connector resources and data sources.

Fix: https://github.com/OpenVPN/terraform-provider-cloudconnexa/issues/113