### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/OpenVPN/terraform-provider-cloudconnexa/security/code-scanning/3](https://github.com/OpenVPN/terraform-provider-cloudconnexa/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow to apply to all jobs. Since the workflow only involves building and testing code, the minimal required permission is `contents: read`. This ensures that the workflow has the least privilege necessary to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
