### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 on:
   pull_request:
     branches:
@@ -45,6 +47,8 @@ jobs:
           go build -v .
   # run acceptance tests in a matrix with Terraform core versions
   test:
+    permissions:
+      contents: read
     if: github.event.pull_request.head.repo.name == github.repository
     environment: TestingEnv
     name: Matrix Test


### PR DESCRIPTION
Potential fix for [https://github.com/OpenVPN/terraform-provider-cloudconnexa/security/code-scanning/4](https://github.com/OpenVPN/terraform-provider-cloudconnexa/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. At the workflow level, we will set `contents: read` as the default permission, which is sufficient for most CI workflows. For the `test` job, we will explicitly add `contents: read` and `id-token: write` (if required for authentication). This ensures that the workflow and its jobs have the minimum permissions necessary to function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
