### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,8 @@
 name: "Stale issues and pull requests"
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 on:
   schedule:
     - cron: "40 17 * * *"


### PR DESCRIPTION
Potential fix for [https://github.com/OpenVPN/terraform-provider-cloudconnexa/security/code-scanning/1](https://github.com/OpenVPN/terraform-provider-cloudconnexa/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's functionality (e.g., marking issues and pull requests as stale, adding labels, and posting comments), the required permissions are:

- `contents: read` (to read repository contents if needed).
- `issues: write` (to add comments and labels to issues).
- `pull-requests: write` (to add comments and labels to pull requests).

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs. This ensures that the `GITHUB_TOKEN` has only the necessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
