### PR TITLE
Fix/settings import incomplete state

### DIFF
--- a/cloudconnexa/data_source_settings.go
+++ b/cloudconnexa/data_source_settings.go
@@ -93,6 +93,16 @@ func dataSourceSettings() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"dns_log_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether DNS logging is enabled.",
+			},
+			"access_visibility_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether access visibility is enabled.",
+			},
 		},
 	}
 }

--- a/cloudconnexa/data_source_settings.go
+++ b/cloudconnexa/data_source_settings.go
@@ -78,7 +78,7 @@ func dataSourceSettings() *schema.Resource {
 			"domain_routing_subnet": {
 				Type:     schema.TypeList,
 				Computed: true,
-				Elem:     domainRoutingSubnet(),
+				Elem:     domainRoutingSubnetSchema(),
 			},
 			"snat": {
 				Type:     schema.TypeBool,

--- a/cloudconnexa/resource_settings.go
+++ b/cloudconnexa/resource_settings.go
@@ -388,8 +388,6 @@ func resourceSettingsRead(ctx context.Context, d *schema.ResourceData, m interfa
 	c := m.(*cloudconnexa.Client)
 	var diags diag.Diagnostics
 
-	// ============ AUTH SETTINGS ============
-
 	allowTrustedDevices, err := c.Settings.GetTrustedDevicesAllowed()
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
@@ -401,8 +399,6 @@ func resourceSettingsRead(ctx context.Context, d *schema.ResourceData, m interfa
 		return append(diags, diag.FromErr(err)...)
 	}
 	d.Set("two_factor_auth", twoFactorAuth)
-
-	// ============ DNS SETTINGS ============
 
 	dnsServers, err := c.Settings.GetDNSServers()
 	if err != nil {
@@ -442,8 +438,6 @@ func resourceSettingsRead(ctx context.Context, d *schema.ResourceData, m interfa
 		d.Set("dns_zones", zoneValues)
 	}
 
-	// ============ USER SETTINGS ============
-
 	connectAuth, err := c.Settings.GetDefaultConnectAuth()
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
@@ -479,8 +473,6 @@ func resourceSettingsRead(ctx context.Context, d *schema.ResourceData, m interfa
 		return append(diags, diag.FromErr(err)...)
 	}
 	d.Set("connection_timeout", connectionTimeout)
-
-	// ============ WPC SETTINGS ============
 
 	clientOptions, err := c.Settings.GetClientOptions()
 	if err != nil {
@@ -527,8 +519,6 @@ func resourceSettingsRead(ctx context.Context, d *schema.ResourceData, m interfa
 		return append(diags, diag.FromErr(err)...)
 	}
 	d.Set("topology", topology)
-
-	// ============ SEPARATE APIs ============
 
 	dnsLog, err := c.Settings.GetDNSLogEnabled()
 	if err != nil {

--- a/cloudconnexa/resource_settings.go
+++ b/cloudconnexa/resource_settings.go
@@ -96,7 +96,7 @@ func resourceSettings() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
-				Elem:     domainRoutingSubnet(),
+				Elem:     domainRoutingSubnetSchema(),
 			},
 			"snat": {
 				Type:     schema.TypeBool,
@@ -163,8 +163,8 @@ func dnsZoneSchema() *schema.Resource {
 	}
 }
 
-// domainRoutingSubnet returns a Terraform schema for domain routing subnet configuration
-func domainRoutingSubnet() *schema.Resource {
+// domainRoutingSubnetSchema returns a Terraform schema for domain routing subnet configuration
+func domainRoutingSubnetSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"ip_v4_address": {

--- a/cloudconnexa/resource_settings_test.go
+++ b/cloudconnexa/resource_settings_test.go
@@ -1,0 +1,76 @@
+package cloudconnexa
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// TestAccCloudConnexaSettings_import tests that importing the settings resource
+// properly populates all attributes from the API.
+func TestAccCloudConnexaSettings_import(t *testing.T) {
+	rn := "cloudconnexa_settings.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudConnexaSettingsConfig(),
+			},
+			{
+				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateId:     "settings",
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccCloudConnexaSettings_basic tests that the settings resource can be created
+// and read back with the correct values.
+func TestAccCloudConnexaSettings_basic(t *testing.T) {
+	rn := "cloudconnexa_settings.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudConnexaSettingsConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rn, "id", "settings"),
+					resource.TestCheckResourceAttrSet(rn, "allow_trusted_devices"),
+					resource.TestCheckResourceAttrSet(rn, "two_factor_auth"),
+					resource.TestCheckResourceAttrSet(rn, "dns_proxy_enabled"),
+					resource.TestCheckResourceAttrSet(rn, "device_allowance_force_update"),
+					resource.TestCheckResourceAttrSet(rn, "snat"),
+					resource.TestCheckResourceAttrSet(rn, "dns_log_enabled"),
+					resource.TestCheckResourceAttrSet(rn, "access_visibility_enabled"),
+					resource.TestCheckResourceAttrSet(rn, "connect_auth"),
+					resource.TestCheckResourceAttrSet(rn, "device_allowance_per_user"),
+					resource.TestCheckResourceAttrSet(rn, "device_enforcement"),
+					resource.TestCheckResourceAttrSet(rn, "profile_distribution"),
+					resource.TestCheckResourceAttrSet(rn, "connection_timeout"),
+					resource.TestCheckResourceAttrSet(rn, "default_region"),
+					resource.TestCheckResourceAttrSet(rn, "topology"),
+				),
+			},
+		},
+	})
+}
+
+// testAccCloudConnexaSettingsConfig generates a minimal Terraform configuration
+// for the settings resource that relies on reading existing settings from the API.
+func testAccCloudConnexaSettingsConfig() string {
+	return fmt.Sprintf(`
+provider "cloudconnexa" {
+	base_url = "https://%s.api.openvpn.com"
+}
+
+resource "cloudconnexa_settings" "test" {
+}
+`, testCloudID)
+}


### PR DESCRIPTION
Fix `terraform import cloudconnexa_settings.settings settings` to populate all attributes from the API.

The conditional checks were introduced in commit 932f26a **Make all settings optional** to read only the settings that users **explicitly** configured.

However, `d.Get()` reads from state, not from config.

During `terraform import`, the state is empty, so all conditions are evaluated to `false` and attributes are skipped.

**Issue #133**