### PR TITLE
Implement retry logic for CloudConnexa API calls

### DIFF
--- a/cloudconnexa/data_source_access_group.go
+++ b/cloudconnexa/data_source_access_group.go
@@ -55,28 +55,27 @@ func dataSourceAccessGroup() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func dataSourceAccessGroupRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	var id = data.Get("id").(string)
 	var group *cloudconnexa.AccessGroup
 	var err error
 	if id != "" {
-		group, err = c.AccessGroups.Get(id)
-		if err != nil {
-			return append(diags, diag.Errorf("Failed to get access group with ID: %s, %s", id, err)...)
-		}
-		if group == nil {
-			return append(diags, diag.Errorf("Access Group with id %s was not found", id)...)
-		}
+		group, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.AccessGroup, error) {
+			return c.AccessGroups.Get(id)
+		})
 	} else {
 		var name = data.Get("name").(string)
-		group, err = c.AccessGroups.GetByName(name)
-		if err != nil {
-			return append(diags, diag.Errorf("Failed to get access group with name: %s, %s", name, err)...)
-		}
-		if group == nil {
-			return append(diags, diag.Errorf("Access Group with name %s was not found", name)...)
-		}
+		group, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.AccessGroup, error) {
+			return c.AccessGroups.GetByName(name)
+		})
+	}
+	if err != nil {
+		return append(diags, diag.FromErr(err)...)
+	}
+	if group == nil {
+		return append(diags, diag.Errorf("Access Group was not found")...)
 	}
 	setAccessGroupData(data, group)
 	return diags

--- a/cloudconnexa/data_source_devices.go
+++ b/cloudconnexa/data_source_devices.go
@@ -66,16 +66,21 @@ func dataSourceDevices() *schema.Resource {
 
 // dataSourceDevicesRead handles the read operation for the devices data source.
 func dataSourceDevicesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 
 	var devices []cloudconnexa.DeviceDetail
 	var err error
 
 	if v, ok := d.GetOk("user_id"); ok {
-		devices, err = c.Devices.ListByUserID(v.(string))
+		devices, err = withRetry(ctx, meta.RetryConfig, func() ([]cloudconnexa.DeviceDetail, error) {
+			return c.Devices.ListByUserID(v.(string))
+		})
 	} else {
-		devices, err = c.Devices.ListAll()
+		devices, err = withRetry(ctx, meta.RetryConfig, func() ([]cloudconnexa.DeviceDetail, error) {
+			return c.Devices.ListAll()
+		})
 	}
 
 	if err != nil {
@@ -151,12 +156,15 @@ func dataSourceDevice() *schema.Resource {
 
 // dataSourceDeviceRead handles the read operation for a single device data source.
 func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 
 	deviceID := d.Get("device_id").(string)
 	userID := d.Get("user_id").(string)
-	device, err := c.Devices.GetByID(userID, deviceID)
+	device, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.DeviceDetail, error) {
+		return c.Devices.GetByID(userID, deviceID)
+	})
 	if err != nil {
 		return diag.Errorf("Failed to get device with ID %s: %s", deviceID, err)
 	}

--- a/cloudconnexa/data_source_host.go
+++ b/cloudconnexa/data_source_host.go
@@ -74,13 +74,16 @@ func dataSourceHost() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func dataSourceHostRead(ctx context.Context, data *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	var id = data.Get("id").(string)
 	var host *cloudconnexa.Host
 	var err error
 	if id != "" {
-		host, err = c.Hosts.Get(id)
+		host, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.Host, error) {
+			return c.Hosts.Get(id)
+		})
 		if err != nil {
 			return append(diags, diag.Errorf("Failed to get host with ID: %s, %s", id, err)...)
 		}
@@ -89,7 +92,9 @@ func dataSourceHostRead(ctx context.Context, data *schema.ResourceData, m interf
 		}
 	} else {
 		var name = data.Get("name").(string)
-		host, err = c.Hosts.GetByName(name)
+		host, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.Host, error) {
+			return c.Hosts.GetByName(name)
+		})
 		if err != nil {
 			return append(diags, diag.Errorf("Failed to get host with name: %s, %s", name, err)...)
 		}

--- a/cloudconnexa/data_source_host_application.go
+++ b/cloudconnexa/data_source_host_application.go
@@ -59,28 +59,27 @@ func dataSourceHostApplication() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func dataSourceHostApplicationRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	var id = data.Get("id").(string)
 	var application *cloudconnexa.ApplicationResponse
 	var err error
 	if id != "" {
-		application, err = c.HostApplications.Get(id)
-		if err != nil {
-			return append(diags, diag.Errorf("Failed to get application with ID: %s, %s", id, err)...)
-		}
-		if application == nil {
-			return append(diags, diag.Errorf("Application with id %s was not found", id)...)
-		}
+		application, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.ApplicationResponse, error) {
+			return c.HostApplications.Get(id)
+		})
 	} else {
 		var name = data.Get("name").(string)
-		application, err = c.HostApplications.GetByName(name)
-		if err != nil {
-			return append(diags, diag.Errorf("Failed to get application with name: %s, %s", name, err)...)
-		}
-		if application == nil {
-			return append(diags, diag.Errorf("Application with name %s was not found", name)...)
-		}
+		application, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.ApplicationResponse, error) {
+			return c.HostApplications.GetByName(name)
+		})
+	}
+	if err != nil {
+		return append(diags, diag.FromErr(err)...)
+	}
+	if application == nil {
+		return append(diags, diag.Errorf("Application was not found")...)
 	}
 	setApplicationData(data, application)
 	return nil

--- a/cloudconnexa/data_source_host_connector.go
+++ b/cloudconnexa/data_source_host_connector.go
@@ -79,14 +79,17 @@ func dataSourceHostConnector() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func dataSourceHostConnectorRead(ctx context.Context, data *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	var id = data.Get("id").(string)
 	var connector *cloudconnexa.HostConnector
 	var token string
 	var err error
 	if id != "" {
-		connector, err = c.HostConnectors.GetByID(id)
+		connector, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.HostConnector, error) {
+			return c.HostConnectors.GetByID(id)
+		})
 		if err != nil {
 			return append(diags, diag.Errorf("Failed to get host connector with ID: %s, %s", id, err)...)
 		}
@@ -95,7 +98,9 @@ func dataSourceHostConnectorRead(ctx context.Context, data *schema.ResourceData,
 		}
 	} else {
 		var name = data.Get("name").(string)
-		connector, err = c.HostConnectors.GetByName(name)
+		connector, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.HostConnector, error) {
+			return c.HostConnectors.GetByName(name)
+		})
 		if err != nil {
 			return append(diags, diag.Errorf("Failed to get host connector with name: %s, %s", name, err)...)
 		}
@@ -103,7 +108,9 @@ func dataSourceHostConnectorRead(ctx context.Context, data *schema.ResourceData,
 			return append(diags, diag.Errorf("Host connector with name %s was not found", name)...)
 		}
 	}
-	token, err = c.HostConnectors.GetToken(connector.ID)
+	token, err = withRetry(ctx, meta.RetryConfig, func() (string, error) {
+		return c.HostConnectors.GetToken(connector.ID)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -117,7 +124,9 @@ func dataSourceHostConnectorRead(ctx context.Context, data *schema.ResourceData,
 	data.Set("ip_v6_address", connector.IPv6Address)
 	data.Set("token", token)
 
-	profile, err := c.HostConnectors.GetProfile(connector.ID)
+	profile, err := withRetry(ctx, meta.RetryConfig, func() (string, error) {
+		return c.HostConnectors.GetProfile(connector.ID)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}

--- a/cloudconnexa/data_source_host_ip_service.go
+++ b/cloudconnexa/data_source_host_ip_service.go
@@ -63,28 +63,27 @@ func dataSourceHostIPService() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func dataSourceHostIPServiceRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	var id = data.Get("id").(string)
 	var service *cloudconnexa.HostIPServiceResponse
 	var err error
 	if id != "" {
-		service, err = c.HostIPServices.Get(id)
-		if err != nil {
-			return append(diags, diag.Errorf("Failed to get host IP service with ID: %s, %s", id, err)...)
-		}
-		if service == nil {
-			return append(diags, diag.Errorf("Host IP service with id %s was not found", id)...)
-		}
+		service, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.HostIPServiceResponse, error) {
+			return c.HostIPServices.Get(id)
+		})
 	} else {
 		var name = data.Get("name").(string)
-		service, err = c.HostIPServices.GetByName(name)
-		if err != nil {
-			return append(diags, diag.Errorf("Failed to get host IP service with name: %s, %s", name, err)...)
-		}
-		if service == nil {
-			return append(diags, diag.Errorf("Host IP service with name %s was not found", name)...)
-		}
+		service, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.HostIPServiceResponse, error) {
+			return c.HostIPServices.GetByName(name)
+		})
+	}
+	if err != nil {
+		return append(diags, diag.FromErr(err)...)
+	}
+	if service == nil {
+		return append(diags, diag.Errorf("Host IP service was not found")...)
 	}
 	setHostIpServiceResourceData(data, service)
 	return nil

--- a/cloudconnexa/data_source_location_context.go
+++ b/cloudconnexa/data_source_location_context.go
@@ -65,29 +65,28 @@ func dataSourceLocationContext() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func dataSourceLocationContextRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	var id = data.Get("id").(string)
-	var context *cloudconnexa.LocationContext
+	var lc *cloudconnexa.LocationContext
 	var err error
 	if id != "" {
-		context, err = c.LocationContexts.Get(id)
-		if err != nil {
-			return append(diags, diag.Errorf("Failed to get location context with ID: %s, %s", id, err)...)
-		}
-		if context == nil {
-			return append(diags, diag.Errorf("Location context with id %s was not found", id)...)
-		}
+		lc, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.LocationContext, error) {
+			return c.LocationContexts.Get(id)
+		})
 	} else {
 		var name = data.Get("name").(string)
-		context, err = c.LocationContexts.GetByName(name)
-		if err != nil {
-			return append(diags, diag.Errorf("Failed to get location context with name: %s, %s", name, err)...)
-		}
-		if context == nil {
-			return append(diags, diag.Errorf("Location context with name %s was not found", name)...)
-		}
+		lc, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.LocationContext, error) {
+			return c.LocationContexts.GetByName(name)
+		})
 	}
-	setLocationContextData(data, context)
+	if err != nil {
+		return append(diags, diag.FromErr(err)...)
+	}
+	if lc == nil {
+		return append(diags, diag.Errorf("Location context was not found")...)
+	}
+	setLocationContextData(data, lc)
 	return nil
 }

--- a/cloudconnexa/data_source_network.go
+++ b/cloudconnexa/data_source_network.go
@@ -82,13 +82,16 @@ func dataSourceNetwork() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func dataSourceNetworkRead(ctx context.Context, data *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	var id = data.Get("id").(string)
 	var network *cloudconnexa.Network
 	var err error
 	if id != "" {
-		network, err = c.Networks.Get(id)
+		network, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.Network, error) {
+			return c.Networks.Get(id)
+		})
 		if err != nil {
 			return append(diags, diag.Errorf("Failed to get network with ID: %s, %s", id, err)...)
 		}
@@ -97,7 +100,9 @@ func dataSourceNetworkRead(ctx context.Context, data *schema.ResourceData, m int
 		}
 	} else {
 		var name = data.Get("name").(string)
-		network, err = c.Networks.GetByName(name)
+		network, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.Network, error) {
+			return c.Networks.GetByName(name)
+		})
 		if err != nil {
 			return append(diags, diag.Errorf("Failed to get network with name: %s, %s", name, err)...)
 		}

--- a/cloudconnexa/data_source_network_application.go
+++ b/cloudconnexa/data_source_network_application.go
@@ -57,28 +57,27 @@ func dataSourceNetworkApplication() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors or warnings
 func dataSourceNetworkApplicationRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	var id = data.Get("id").(string)
 	var application *cloudconnexa.NetworkApplicationResponse
 	var err error
 	if id != "" {
-		application, err = c.NetworkApplications.Get(id)
-		if err != nil {
-			return append(diags, diag.Errorf("Failed to get network application with ID: %s, %s", id, err)...)
-		}
-		if application == nil {
-			return append(diags, diag.Errorf("Network application with id %s was not found", id)...)
-		}
+		application, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.NetworkApplicationResponse, error) {
+			return c.NetworkApplications.Get(id)
+		})
 	} else {
 		var name = data.Get("name").(string)
-		application, err = c.NetworkApplications.GetByName(name)
-		if err != nil {
-			return append(diags, diag.Errorf("Failed to get network application with name: %s, %s", name, err)...)
-		}
-		if application == nil {
-			return append(diags, diag.Errorf("Network application with name %s was not found", name)...)
-		}
+		application, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.NetworkApplicationResponse, error) {
+			return c.NetworkApplications.GetByName(name)
+		})
+	}
+	if err != nil {
+		return append(diags, diag.FromErr(err)...)
+	}
+	if application == nil {
+		return append(diags, diag.Errorf("Network application was not found")...)
 	}
 	setNetworkApplicationData(data, application)
 	return nil

--- a/cloudconnexa/data_source_network_connector.go
+++ b/cloudconnexa/data_source_network_connector.go
@@ -84,13 +84,16 @@ func dataSourceNetworkConnector() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func dataSourceNetworkConnectorRead(ctx context.Context, data *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	var id = data.Get("id").(string)
 	var connector *cloudconnexa.NetworkConnector
 	var err error
 	if id != "" {
-		connector, err = c.NetworkConnectors.GetByID(id)
+		connector, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.NetworkConnector, error) {
+			return c.NetworkConnectors.GetByID(id)
+		})
 		if err != nil {
 			return append(diags, diag.Errorf("Failed to get network connector with ID: %s, %s", id, err)...)
 		}
@@ -99,7 +102,9 @@ func dataSourceNetworkConnectorRead(ctx context.Context, data *schema.ResourceDa
 		}
 	} else {
 		var name = data.Get("name").(string)
-		connector, err = c.NetworkConnectors.GetByName(name)
+		connector, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.NetworkConnector, error) {
+			return c.NetworkConnectors.GetByName(name)
+		})
 		if err != nil {
 			return append(diags, diag.Errorf("Failed to get network connector with name: %s, %s", name, err)...)
 		}
@@ -110,12 +115,16 @@ func dataSourceNetworkConnectorRead(ctx context.Context, data *schema.ResourceDa
 
 	setNetworkConnectorData(data, connector)
 	if connector.TunnelingProtocol == "OPENVPN" {
-		token, err := c.NetworkConnectors.GetToken(connector.ID)
+		token, err := withRetry(ctx, meta.RetryConfig, func() (string, error) {
+			return c.NetworkConnectors.GetToken(connector.ID)
+		})
 		if err != nil {
 			return append(diags, diag.FromErr(err)...)
 		}
 		data.Set("token", token)
-		profile, err := c.NetworkConnectors.GetProfile(connector.ID)
+		profile, err := withRetry(ctx, meta.RetryConfig, func() (string, error) {
+			return c.NetworkConnectors.GetProfile(connector.ID)
+		})
 		if err != nil {
 			return append(diags, diag.FromErr(err)...)
 		}

--- a/cloudconnexa/data_source_network_ip_service.go
+++ b/cloudconnexa/data_source_network_ip_service.go
@@ -63,28 +63,27 @@ func dataSourceNetworkIPService() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func dataSourceNetworkIPServiceRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	var id = data.Get("id").(string)
 	var service *cloudconnexa.NetworkIPServiceResponse
 	var err error
 	if id != "" {
-		service, err = c.NetworkIPServices.Get(id)
-		if err != nil {
-			return append(diags, diag.Errorf("Failed to get network IP service with ID: %s, %s", id, err)...)
-		}
-		if service == nil {
-			return append(diags, diag.Errorf("Network IP service with id %s was not found", id)...)
-		}
+		service, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.NetworkIPServiceResponse, error) {
+			return c.NetworkIPServices.Get(id)
+		})
 	} else {
 		var name = data.Get("name").(string)
-		service, err = c.NetworkIPServices.GetByName(name)
-		if err != nil {
-			return append(diags, diag.Errorf("Failed to get network IP service with name: %s, %s", name, err)...)
-		}
-		if service == nil {
-			return append(diags, diag.Errorf("Network IP service with name %s was not found", name)...)
-		}
+		service, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.NetworkIPServiceResponse, error) {
+			return c.NetworkIPServices.GetByName(name)
+		})
+	}
+	if err != nil {
+		return append(diags, diag.FromErr(err)...)
+	}
+	if service == nil {
+		return append(diags, diag.Errorf("Network IP service was not found")...)
 	}
 	setNetworkIpServiceResourceData(data, service)
 	return nil

--- a/cloudconnexa/data_source_network_routes.go
+++ b/cloudconnexa/data_source_network_routes.go
@@ -69,14 +69,17 @@ func dataSourceNetworkRoutes() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func dataSourceNetworkRoutesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 
 	id := d.Get("id").(string)
 	if id == "" {
 		return append(diags, diag.Errorf("ID cannot be empty")...)
 	}
-	network, err := c.Networks.Get(id)
+	network, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.Network, error) {
+		return c.Networks.Get(id)
+	})
 	if err != nil {
 		return append(diags, diag.Errorf("Failed to get network with ID: %s, %s", id, err)...)
 	}

--- a/cloudconnexa/data_source_sessions.go
+++ b/cloudconnexa/data_source_sessions.go
@@ -126,7 +126,8 @@ func dataSourceSessions() *schema.Resource {
 
 // dataSourceSessionsRead handles the read operation for the sessions data source.
 func dataSourceSessionsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 
 	options := cloudconnexa.SessionsListOptions{
@@ -153,7 +154,9 @@ func dataSourceSessionsRead(ctx context.Context, d *schema.ResourceData, m inter
 		options.EndDate = &t
 	}
 
-	sessions, err := c.Sessions.ListAll(options)
+	sessions, err := withRetry(ctx, meta.RetryConfig, func() ([]cloudconnexa.Session, error) {
+		return c.Sessions.ListAll(options)
+	})
 	if err != nil {
 		return diag.Errorf("Failed to get sessions: %s", err)
 	}

--- a/cloudconnexa/data_source_user.go
+++ b/cloudconnexa/data_source_user.go
@@ -119,10 +119,13 @@ func dataSourceUser() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	userName := d.Get("username").(string)
-	user, err := c.Users.GetByUsername(userName)
+	user, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.User, error) {
+		return c.Users.GetByUsername(userName)
+	})
 	if err != nil {
 		return diag.Errorf("Failed to get user with username: %s, %s", userName, err)
 	}

--- a/cloudconnexa/data_source_user_group.go
+++ b/cloudconnexa/data_source_user_group.go
@@ -107,13 +107,16 @@ func dataSourceUserGroup() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func dataSourceUserGroupRead(ctx context.Context, data *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	var id = data.Get("id").(string)
 	var userGroup *cloudconnexa.UserGroup
 	var err error
 	if id != "" {
-		userGroup, err = c.UserGroups.GetByID(id)
+		userGroup, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.UserGroup, error) {
+			return c.UserGroups.GetByID(id)
+		})
 		if err != nil {
 			return append(diags, diag.Errorf("Failed to get user group with ID: %s, %s", id, err)...)
 		}
@@ -122,7 +125,9 @@ func dataSourceUserGroupRead(ctx context.Context, data *schema.ResourceData, m i
 		}
 	} else {
 		var name = data.Get("name").(string)
-		userGroup, err = c.UserGroups.GetByName(name)
+		userGroup, err = withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.UserGroup, error) {
+			return c.UserGroups.GetByName(name)
+		})
 		if err != nil {
 			return append(diags, diag.Errorf("Failed to get user group with name: %s, %s", name, err)...)
 		}

--- a/cloudconnexa/data_source_vpn_region.go
+++ b/cloudconnexa/data_source_vpn_region.go
@@ -60,11 +60,14 @@ func dataSourceVpnRegion() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func dataSourceVpnRegionRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := d.Get("id").(string)
 
-	vpnRegion, err := c.VPNRegions.GetByID(id)
+	vpnRegion, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.VpnRegion, error) {
+		return c.VPNRegions.GetByID(id)
+	})
 	if err != nil {
 		return diag.Errorf("Failed to get vpn region with ID: %s, %s", id, err)
 	}

--- a/cloudconnexa/data_source_vpn_regions.go
+++ b/cloudconnexa/data_source_vpn_regions.go
@@ -69,10 +69,13 @@ func dataSourceVpnRegions() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func dataSourceVpnRegionsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 
-	regions, err := c.VPNRegions.List()
+	regions, err := withRetry(ctx, meta.RetryConfig, func() ([]cloudconnexa.VpnRegion, error) {
+		return c.VPNRegions.List()
+	})
 	if err != nil {
 		return diag.Errorf("Failed to get vpn regions: %s", err)
 	}

--- a/cloudconnexa/provider.go
+++ b/cloudconnexa/provider.go
@@ -17,6 +17,9 @@ const ClientIDEnvVar = "CLOUDCONNEXA_CLIENT_ID"
 // ClientSecretEnvVar is the environment variable name for the CloudConnexa client secret
 const ClientSecretEnvVar = "CLOUDCONNEXA_CLIENT_SECRET"
 
+// MaxRetriesEnvVar is the environment variable name for the maximum number of retries
+const MaxRetriesEnvVar = "CLOUDCONNEXA_MAX_RETRIES"
+
 // cloudIDPattern validates that cloud_id contains only alphanumeric characters and hyphens
 var cloudIDPattern = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
 
@@ -26,6 +29,12 @@ var version = "v1.2.1"
 // Token represents the authentication token structure returned by the CloudConnexa API
 type Token struct {
 	AccessToken string `json:"access_token"`
+}
+
+// providerMeta holds the configured CloudConnexa client and retry settings.
+type providerMeta struct {
+	Client      *cloudconnexa.Client
+	RetryConfig retryConfig
 }
 
 // Provider returns a Terraform provider for CloudConnexa.
@@ -62,6 +71,14 @@ func Provider() *schema.Provider {
 				Description: "Cloud ID",
 				Type:        schema.TypeString,
 				Optional:    true,
+			},
+			"max_retries": {
+				Description: "Maximum number of retries for rate-limited (HTTP 429) or transient (HTTP 503) API requests. " +
+					"Uses exponential backoff between attempts. Set to 0 to disable retries. " +
+					"The value can be sourced from the `CLOUDCONNEXA_MAX_RETRIES` environment variable. Defaults to `5`.",
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc(MaxRetriesEnvVar, 5),
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -142,5 +159,13 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		return nil, diags
 	}
 	cloudConnexaClient.UserAgent = fmt.Sprintf("terraform-provider-cloudconnexa/%v", version)
-	return cloudConnexaClient, nil
+
+	maxRetries := d.Get("max_retries").(int)
+	cfg := defaultRetryConfig()
+	cfg.MaxRetries = maxRetries
+
+	return &providerMeta{
+		Client:      cloudConnexaClient,
+		RetryConfig: cfg,
+	}, nil
 }

--- a/cloudconnexa/resource_access_group.go
+++ b/cloudconnexa/resource_access_group.go
@@ -143,10 +143,13 @@ func resourceDestination() *schema.Resource {
 
 // resourceAccessGroupCreate creates a new access group in CloudConnexa
 func resourceAccessGroupCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	request := resourceDataToAccessGroup(d)
-	accessGroup, err := c.AccessGroups.Create(request)
+	accessGroup, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.AccessGroup, error) {
+		return c.AccessGroups.Create(request)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -156,10 +159,13 @@ func resourceAccessGroupCreate(ctx context.Context, d *schema.ResourceData, m in
 
 // resourceAccessGroupRead retrieves an access group from CloudConnexa
 func resourceAccessGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := d.Id()
-	ag, err := c.AccessGroups.Get(id)
+	ag, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.AccessGroup, error) {
+		return c.AccessGroups.Get(id)
+	})
 	if err != nil {
 		return append(diags, diag.Errorf("Failed to get access group with ID: %s, %s", id, err)...)
 	}
@@ -173,10 +179,13 @@ func resourceAccessGroupRead(ctx context.Context, d *schema.ResourceData, m inte
 
 // resourceAccessGroupUpdate updates an existing access group in CloudConnexa
 func resourceAccessGroupUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	ag := resourceDataToAccessGroup(d)
-	savedAccessGroup, err := c.AccessGroups.Update(d.Id(), ag)
+	savedAccessGroup, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.AccessGroup, error) {
+		return c.AccessGroups.Update(d.Id(), ag)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -186,10 +195,13 @@ func resourceAccessGroupUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 // resourceAccessGroupDelete removes an access group from CloudConnexa
 func resourceAccessGroupDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := d.Id()
-	err := c.AccessGroups.Delete(id)
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.AccessGroups.Delete(id)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}

--- a/cloudconnexa/resource_access_group_test.go
+++ b/cloudconnexa/resource_access_group_test.go
@@ -178,7 +178,7 @@ func testAccCheckCloudConnexaAccessGroupExists(rn string, id *string) resource.T
 			return errors.New("no ID is set")
 		}
 
-		c := testAccProvider.Meta().(*cloudconnexa.Client)
+		c := testAccProvider.Meta().(*providerMeta).Client
 		ag, err := c.AccessGroups.Get(rs.Primary.ID)
 		if err != nil {
 			return err
@@ -194,7 +194,7 @@ func testAccCheckCloudConnexaAccessGroupExists(rn string, id *string) resource.T
 // testAccCheckCloudConnexaAccessGroupDestroy verifies that every access group
 // previously tracked in state has been removed from the CloudConnexa API.
 func testAccCheckCloudConnexaAccessGroupDestroy(s *terraform.State) error {
-	c := testAccProvider.Meta().(*cloudconnexa.Client)
+	c := testAccProvider.Meta().(*providerMeta).Client
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cloudconnexa_access_group" {
 			continue

--- a/cloudconnexa/resource_device.go
+++ b/cloudconnexa/resource_device.go
@@ -80,7 +80,8 @@ func resourceDevice() *schema.Resource {
 
 // resourceDeviceCreate provisions a new device for the given user.
 func resourceDeviceCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 
 	userID := d.Get("user_id").(string)
 	req := cloudconnexa.DeviceCreateRequest{
@@ -89,7 +90,9 @@ func resourceDeviceCreate(ctx context.Context, d *schema.ResourceData, m interfa
 		ClientUUID:  d.Get("client_uuid").(string),
 	}
 
-	device, err := c.Devices.Create(userID, req)
+	device, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.DeviceDetail, error) {
+		return c.Devices.Create(userID, req)
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -100,10 +103,13 @@ func resourceDeviceCreate(ctx context.Context, d *schema.ResourceData, m interfa
 
 // resourceDeviceRead refreshes Terraform state from the CloudConnexa API.
 func resourceDeviceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 
 	userID := d.Get("user_id").(string)
-	device, err := c.Devices.GetByID(userID, d.Id())
+	device, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.DeviceDetail, error) {
+		return c.Devices.GetByID(userID, d.Id())
+	})
 	if err != nil {
 		return diag.Errorf("Failed to get device with ID %s: %s", d.Id(), err)
 	}
@@ -123,7 +129,8 @@ func resourceDeviceRead(ctx context.Context, d *schema.ResourceData, m interface
 
 // resourceDeviceUpdate pushes name/description changes back to CloudConnexa.
 func resourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 
 	if d.HasChanges("name", "description") {
 		// Both fields are always sent so omitempty on the SDK struct doesn't blank a value the user kept.
@@ -132,7 +139,9 @@ func resourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 			Description: d.Get("description").(string),
 		}
 		userID := d.Get("user_id").(string)
-		if _, err := c.Devices.Update(userID, d.Id(), req); err != nil {
+		if _, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.DeviceDetail, error) {
+			return c.Devices.Update(userID, d.Id(), req)
+		}); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -142,10 +151,13 @@ func resourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 
 // resourceDeviceDelete removes the device from CloudConnexa.
 func resourceDeviceDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 
 	userID := d.Get("user_id").(string)
-	if err := c.Devices.Delete(userID, d.Id()); err != nil {
+	if err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.Devices.Delete(userID, d.Id())
+	}); err != nil {
 		return diag.FromErr(err)
 	}
 	d.SetId("")

--- a/cloudconnexa/resource_device_test.go
+++ b/cloudconnexa/resource_device_test.go
@@ -98,7 +98,7 @@ func testAccCheckCloudConnexaDeviceExists(n string) resource.TestCheckFunc {
 		if userID == "" {
 			return errors.New("no user_id is set")
 		}
-		c := testAccProvider.Meta().(*cloudconnexa.Client)
+		c := testAccProvider.Meta().(*providerMeta).Client
 		if _, err := c.Devices.GetByID(userID, rs.Primary.ID); err != nil {
 			return fmt.Errorf("device %s not retrievable: %w", rs.Primary.ID, err)
 		}
@@ -109,7 +109,7 @@ func testAccCheckCloudConnexaDeviceExists(n string) resource.TestCheckFunc {
 // testAccCheckCloudConnexaDeviceDestroy confirms the device is gone from the
 // API after Terraform destroys the resource.
 func testAccCheckCloudConnexaDeviceDestroy(s *terraform.State) error {
-	c := testAccProvider.Meta().(*cloudconnexa.Client)
+	c := testAccProvider.Meta().(*providerMeta).Client
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cloudconnexa_device" {
 			continue

--- a/cloudconnexa/resource_dns_record.go
+++ b/cloudconnexa/resource_dns_record.go
@@ -74,7 +74,8 @@ func resourceDnsRecord() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred
 func resourceDnsRecordCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	domain := d.Get("domain").(string)
 	description := d.Get("description").(string)
@@ -94,7 +95,9 @@ func resourceDnsRecordCreate(ctx context.Context, d *schema.ResourceData, m inte
 		IPV4Addresses: ipV4AddressesSlice,
 		IPV6Addresses: ipV6AddressesSlice,
 	}
-	dnsRecord, err := c.DNSRecords.Create(dr)
+	dnsRecord, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.DNSRecord, error) {
+		return c.DNSRecords.Create(dr)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -112,10 +115,13 @@ func resourceDnsRecordCreate(ctx context.Context, d *schema.ResourceData, m inte
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred
 func resourceDnsRecordRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := d.Id()
-	r, err := c.DNSRecords.GetByID(id)
+	r, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.DNSRecord, error) {
+		return c.DNSRecords.GetByID(id)
+	})
 	if err != nil {
 		if isDNSRecordNotFoundErr(err) {
 			d.SetId("")
@@ -144,7 +150,8 @@ func resourceDnsRecordRead(ctx context.Context, d *schema.ResourceData, m interf
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred
 func resourceDnsRecordUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	_, domain := d.GetChange("domain")
 	_, description := d.GetChange("description")
@@ -159,7 +166,9 @@ func resourceDnsRecordUpdate(ctx context.Context, d *schema.ResourceData, m inte
 		IPV4Addresses: ipV4AddressesSlice,
 		IPV6Addresses: ipV6AddressesSlice,
 	}
-	err := c.DNSRecords.Update(dr)
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.DNSRecords.Update(dr)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -176,10 +185,13 @@ func resourceDnsRecordUpdate(ctx context.Context, d *schema.ResourceData, m inte
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred
 func resourceDnsRecordDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	recordId := d.Id()
-	err := c.DNSRecords.Delete(recordId)
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.DNSRecords.Delete(recordId)
+	})
 	if err != nil && !isDNSRecordNotFoundErr(err) {
 		return append(diags, diag.FromErr(err)...)
 	}

--- a/cloudconnexa/resource_dns_record_test.go
+++ b/cloudconnexa/resource_dns_record_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openvpn/cloudconnexa-go-client/v2/cloudconnexa"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -47,7 +45,7 @@ func TestAccCloudConnexaDnsRecord_basic(t *testing.T) {
 // Returns:
 //   - error: An error if the DNS record still exists or if there was an error checking its existence
 func testAccCheckCloudConnexaDnsRecordDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*cloudconnexa.Client)
+	client := testAccProvider.Meta().(*providerMeta).Client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cloudconnexa_dns_record" {

--- a/cloudconnexa/resource_host.go
+++ b/cloudconnexa/resource_host.go
@@ -83,7 +83,8 @@ func gatewaysIdsFromResource(d *schema.ResourceData) []string {
 
 // resourceHostCreate creates a new CloudConnexa host
 func resourceHostCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	h := cloudconnexa.Host{
 		Name:           d.Get("name").(string),
@@ -92,7 +93,9 @@ func resourceHostCreate(ctx context.Context, d *schema.ResourceData, m interface
 		InternetAccess: d.Get("internet_access").(string),
 		GatewaysIDs:    gatewaysIdsFromResource(d),
 	}
-	host, err := c.Hosts.Create(h)
+	host, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.Host, error) {
+		return c.Hosts.Create(h)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -103,10 +106,13 @@ func resourceHostCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 // resourceHostRead retrieves information about an existing CloudConnexa host
 func resourceHostRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := d.Id()
-	host, err := c.Hosts.Get(id)
+	host, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.Host, error) {
+		return c.Hosts.Get(id)
+	})
 	if err != nil {
 		return append(diags, diag.Errorf("Failed to get host with ID: %s, %s", id, err)...)
 	}
@@ -122,19 +128,22 @@ func resourceHostRead(ctx context.Context, d *schema.ResourceData, m interface{}
 
 // resourceHostUpdate updates an existing CloudConnexa host
 func resourceHostUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	_, newName := d.GetChange("name")
 	_, newDescription := d.GetChange("description")
 	_, newDomain := d.GetChange("domain")
 	_, newAccess := d.GetChange("internet_access")
-	err := c.Hosts.Update(cloudconnexa.Host{
-		ID:             d.Id(),
-		Name:           newName.(string),
-		Description:    newDescription.(string),
-		Domain:         newDomain.(string),
-		InternetAccess: newAccess.(string),
-		GatewaysIDs:    gatewaysIdsFromResource(d),
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.Hosts.Update(cloudconnexa.Host{
+			ID:             d.Id(),
+			Name:           newName.(string),
+			Description:    newDescription.(string),
+			Domain:         newDomain.(string),
+			InternetAccess: newAccess.(string),
+			GatewaysIDs:    gatewaysIdsFromResource(d),
+		})
 	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
@@ -144,10 +153,13 @@ func resourceHostUpdate(ctx context.Context, d *schema.ResourceData, m interface
 
 // resourceHostDelete removes an existing CloudConnexa host
 func resourceHostDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	hostId := d.Id()
-	err := c.Hosts.Delete(hostId)
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.Hosts.Delete(hostId)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}

--- a/cloudconnexa/resource_host_application.go
+++ b/cloudconnexa/resource_host_application.go
@@ -60,9 +60,12 @@ func resourceHostApplication() *schema.Resource {
 
 // resourceHostApplicationUpdate updates an existing host application
 func resourceHostApplicationUpdate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 
-	_, err := c.HostApplications.Update(data.Id(), resourceDataToHostApplication(data))
+	_, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.ApplicationResponse, error) {
+		return c.HostApplications.Update(data.Id(), resourceDataToHostApplication(data))
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -137,10 +140,13 @@ func customApplicationTypesConfig() map[string]*schema.Schema {
 
 // resourceHostApplicationRead reads the state of a host application
 func resourceHostApplicationRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := data.Id()
-	application, err := c.HostApplications.Get(id)
+	application, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.ApplicationResponse, error) {
+		return c.HostApplications.Get(id)
+	})
 	if err != nil {
 		return append(diags, diag.Errorf("Failed to get host application with ID: %s, %s", id, err)...)
 	}
@@ -164,9 +170,12 @@ func setApplicationData(data *schema.ResourceData, application *cloudconnexa.App
 
 // resourceHostApplicationDelete deletes a host application
 func resourceHostApplicationDelete(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
-	err := c.HostApplications.Delete(data.Id())
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.HostApplications.Delete(data.Id())
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -218,10 +227,13 @@ func flattenApplicationRoutes(routes []*cloudconnexa.Route) []map[string]interfa
 
 // resourceHostApplicationCreate creates a new host application
 func resourceHostApplicationCreate(ctx context.Context, data *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	client := meta.Client
 
 	application := resourceDataToHostApplication(data)
-	createdApplication, err := client.HostApplications.Create(application)
+	createdApplication, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.ApplicationResponse, error) {
+		return client.HostApplications.Create(application)
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/cloudconnexa/resource_host_connector.go
+++ b/cloudconnexa/resource_host_connector.go
@@ -87,7 +87,8 @@ func resourceHostConnector() *schema.Resource {
 // resourceHostConnectorUpdate updates an existing CloudConnexa host connector with new configuration.
 // It handles updating the connector's name, description, VPN region, and status.
 func resourceHostConnectorUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 
 	// Handle status change (suspend/activate)
@@ -95,11 +96,11 @@ func resourceHostConnectorUpdate(ctx context.Context, d *schema.ResourceData, m 
 		_, newStatus := d.GetChange("status")
 		switch newStatus.(string) {
 		case "SUSPENDED":
-			if err := c.HostConnectors.Suspend(d.Id()); err != nil {
+			if err := withRetryNoBody(ctx, meta.RetryConfig, func() error { return c.HostConnectors.Suspend(d.Id()) }); err != nil {
 				return append(diags, diag.FromErr(err)...)
 			}
 		case "ACTIVE":
-			if err := c.HostConnectors.Activate(d.Id()); err != nil {
+			if err := withRetryNoBody(ctx, meta.RetryConfig, func() error { return c.HostConnectors.Activate(d.Id()) }); err != nil {
 				return append(diags, diag.FromErr(err)...)
 			}
 		}
@@ -113,7 +114,9 @@ func resourceHostConnectorUpdate(ctx context.Context, d *schema.ResourceData, m 
 			Description: d.Get("description").(string),
 			VpnRegionID: d.Get("vpn_region_id").(string),
 		}
-		_, err := c.HostConnectors.Update(connector)
+		_, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.HostConnector, error) {
+			return c.HostConnectors.Update(connector)
+		})
 		if err != nil {
 			return append(diags, diag.FromErr(err)...)
 		}
@@ -125,7 +128,8 @@ func resourceHostConnectorUpdate(ctx context.Context, d *schema.ResourceData, m 
 // resourceHostConnectorCreate creates a new CloudConnexa host connector.
 // It initializes the connector with the specified configuration and returns a warning about manual setup requirements.
 func resourceHostConnectorCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	name := d.Get("name").(string)
 	description := d.Get("description").(string)
@@ -138,17 +142,23 @@ func resourceHostConnectorCreate(ctx context.Context, d *schema.ResourceData, m 
 		VpnRegionID:     vpnRegionId,
 		Description:     description,
 	}
-	conn, err := c.HostConnectors.Create(connector, networkItemId)
+	conn, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.HostConnector, error) {
+		return c.HostConnectors.Create(connector, networkItemId)
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	d.SetId(conn.ID)
-	profile, err := c.HostConnectors.GetProfile(conn.ID)
+	profile, err := withRetry(ctx, meta.RetryConfig, func() (string, error) {
+		return c.HostConnectors.GetProfile(conn.ID)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
 	d.Set("profile", profile)
-	token, err := c.HostConnectors.GetToken(conn.ID)
+	token, err := withRetry(ctx, meta.RetryConfig, func() (string, error) {
+		return c.HostConnectors.GetToken(conn.ID)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -163,14 +173,19 @@ func resourceHostConnectorCreate(ctx context.Context, d *schema.ResourceData, m 
 // resourceHostConnectorRead retrieves the current state of a CloudConnexa host connector.
 // It fetches the connector's configuration, profile, and token information.
 func resourceHostConnectorRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := d.Id()
-	connector, err := c.HostConnectors.GetByID(id)
+	connector, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.HostConnector, error) {
+		return c.HostConnectors.GetByID(id)
+	})
 	if err != nil {
 		return append(diags, diag.Errorf("Failed to get host connector with ID: %s, %s", id, err)...)
 	}
-	token, err := c.HostConnectors.GetToken(d.Id())
+	token, err := withRetry(ctx, meta.RetryConfig, func() (string, error) {
+		return c.HostConnectors.GetToken(d.Id())
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -187,7 +202,9 @@ func resourceHostConnectorRead(ctx context.Context, d *schema.ResourceData, m in
 		d.Set("ip_v6_address", connector.IPv6Address)
 		d.Set("connection_status", connector.ConnectionStatus)
 		d.Set("token", token)
-		profile, err := c.HostConnectors.GetProfile(connector.ID)
+		profile, err := withRetry(ctx, meta.RetryConfig, func() (string, error) {
+			return c.HostConnectors.GetProfile(connector.ID)
+		})
 		if err != nil {
 			return append(diags, diag.FromErr(err)...)
 		}
@@ -199,9 +216,12 @@ func resourceHostConnectorRead(ctx context.Context, d *schema.ResourceData, m in
 // resourceHostConnectorDelete removes a CloudConnexa host connector.
 // It deletes the connector and its associated host configuration.
 func resourceHostConnectorDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
-	err := c.HostConnectors.Delete(d.Id(), d.Get("host_id").(string))
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.HostConnectors.Delete(d.Id(), d.Get("host_id").(string))
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}

--- a/cloudconnexa/resource_host_connector_test.go
+++ b/cloudconnexa/resource_host_connector_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openvpn/cloudconnexa-go-client/v2/cloudconnexa"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -68,7 +66,7 @@ func testAccCheckCloudConnexaConnectorExists(n string) resource.TestCheckFunc {
 // Returns:
 //   - error: An error if the connector still exists or if there was an error checking its existence
 func testAccCheckCloudConnexaConnectorDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*cloudconnexa.Client)
+	client := testAccProvider.Meta().(*providerMeta).Client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cloudconnexa_host_connector" {

--- a/cloudconnexa/resource_host_ip_service.go
+++ b/cloudconnexa/resource_host_ip_service.go
@@ -59,9 +59,12 @@ func resourceHostIPService() *schema.Resource {
 
 // resourceHostIpServiceUpdate updates an existing host IP service
 func resourceHostIpServiceUpdate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 
-	_, err := c.HostIPServices.Update(data.Id(), resourceDataToHostIpService(data))
+	_, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.HostIPServiceResponse, error) {
+		return c.HostIPServices.Update(data.Id(), resourceDataToHostIpService(data))
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -120,10 +123,13 @@ func customHostServiceTypesConfig() map[string]*schema.Schema {
 
 // resourceHostIpServiceRead reads the state of a host IP service
 func resourceHostIpServiceRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := data.Id()
-	service, err := c.HostIPServices.Get(id)
+	service, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.HostIPServiceResponse, error) {
+		return c.HostIPServices.Get(id)
+	})
 	if err != nil {
 		return append(diags, diag.Errorf("Failed to get host IP service with ID: %s, %s", id, err)...)
 	}
@@ -148,9 +154,12 @@ func setHostIpServiceResourceData(data *schema.ResourceData, service *cloudconne
 
 // resourceHostIpServiceDelete deletes a host IP service
 func resourceHostIpServiceDelete(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
-	err := c.HostIPServices.Delete(data.Id())
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.HostIPServices.Delete(data.Id())
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -190,10 +199,13 @@ func flattenCustomHostServiceTypes(types []*cloudconnexa.CustomIPServiceType) in
 
 // resourceHostIpServiceCreate creates a new host IP service
 func resourceHostIpServiceCreate(ctx context.Context, data *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	client := meta.Client
 
 	service := resourceDataToHostIpService(data)
-	createdService, err := client.HostIPServices.Create(service)
+	createdService, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.HostIPServiceResponse, error) {
+		return client.HostIPServices.Create(service)
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/cloudconnexa/resource_host_ip_service_test.go
+++ b/cloudconnexa/resource_host_ip_service_test.go
@@ -68,7 +68,7 @@ func testAccCheckCloudConnexaServiceExists(rn, _ string) resource.TestCheckFunc 
 			return errors.New("no ID is set")
 		}
 
-		c := testAccProvider.Meta().(*cloudconnexa.Client)
+		c := testAccProvider.Meta().(*providerMeta).Client
 		_, err := c.HostIPServices.Get(rs.Primary.ID)
 		if err != nil {
 			return err
@@ -86,7 +86,7 @@ func testAccCheckCloudConnexaServiceExists(rn, _ string) resource.TestCheckFunc 
 // Returns:
 //   - error: An error if the service still exists or if there was an error checking its existence
 func testAccCheckCloudConnexaServiceDestroy(state *terraform.State) error {
-	c := testAccProvider.Meta().(*cloudconnexa.Client)
+	c := testAccProvider.Meta().(*providerMeta).Client
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "cloudconnexa_host_ip_service" {
 			continue

--- a/cloudconnexa/resource_host_test.go
+++ b/cloudconnexa/resource_host_test.go
@@ -73,7 +73,7 @@ func testAccCheckCloudConnexaHostExists(rn string) resource.TestCheckFunc {
 		if rs.Primary.ID == "" {
 			return errors.New("no ID is set")
 		}
-		c := testAccProvider.Meta().(*cloudconnexa.Client)
+		c := testAccProvider.Meta().(*providerMeta).Client
 		h, err := c.Hosts.Get(rs.Primary.ID)
 		if err != nil {
 			return err
@@ -88,7 +88,7 @@ func testAccCheckCloudConnexaHostExists(rn string) resource.TestCheckFunc {
 // testAccCheckCloudConnexaHostDestroy confirms every host tracked in state
 // has been removed from the API after Terraform destroys the resource.
 func testAccCheckCloudConnexaHostDestroy(s *terraform.State) error {
-	c := testAccProvider.Meta().(*cloudconnexa.Client)
+	c := testAccProvider.Meta().(*providerMeta).Client
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cloudconnexa_host" {
 			continue
@@ -199,7 +199,7 @@ func TestUnitResourceHostCreate_Success(t *testing.T) {
 		"domain":       "e",
 		"gateways_ids": []interface{}{"gw-1"},
 	})
-	diags := resourceHostCreate(context.Background(), d, c)
+	diags := resourceHostCreate(context.Background(), d, &providerMeta{Client: c, RetryConfig: defaultRetryConfig()})
 	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
 	assert.Equal(t, "new-host", d.Id())
 }
@@ -212,7 +212,7 @@ func TestUnitResourceHostCreate_Error(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, resourceHost().Schema, map[string]interface{}{
 		"name": "to-fail",
 	})
-	diags := resourceHostCreate(context.Background(), d, c)
+	diags := resourceHostCreate(context.Background(), d, &providerMeta{Client: c, RetryConfig: defaultRetryConfig()})
 	assert.True(t, diags.HasError())
 	assert.Empty(t, d.Id(), "ID must remain empty when Create fails")
 }
@@ -241,7 +241,7 @@ func TestUnitResourceHostRead_Success(t *testing.T) {
 		"name": "ignored",
 	})
 	d.SetId("host-id")
-	diags := resourceHostRead(context.Background(), d, c)
+	diags := resourceHostRead(context.Background(), d, &providerMeta{Client: c, RetryConfig: defaultRetryConfig()})
 	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
 	assert.Equal(t, "my-host", d.Get("name"))
 	assert.Equal(t, "desc", d.Get("description"))
@@ -258,7 +258,7 @@ func TestUnitResourceHostRead_Error(t *testing.T) {
 		"name": "x",
 	})
 	d.SetId("host-id")
-	diags := resourceHostRead(context.Background(), d, c)
+	diags := resourceHostRead(context.Background(), d, &providerMeta{Client: c, RetryConfig: defaultRetryConfig()})
 	assert.True(t, diags.HasError())
 }
 
@@ -291,7 +291,7 @@ func TestUnitResourceHostUpdate_Success(t *testing.T) {
 		"internet_access": "SPLIT_TUNNEL_OFF",
 	})
 	d.SetId("host-id")
-	diags := resourceHostUpdate(context.Background(), d, c)
+	diags := resourceHostUpdate(context.Background(), d, &providerMeta{Client: c, RetryConfig: defaultRetryConfig()})
 	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
 	assert.Equal(t, "updated", d.Get("name"))
 }
@@ -305,7 +305,7 @@ func TestUnitResourceHostUpdate_Error(t *testing.T) {
 		"name": "x",
 	})
 	d.SetId("host-id")
-	diags := resourceHostUpdate(context.Background(), d, c)
+	diags := resourceHostUpdate(context.Background(), d, &providerMeta{Client: c, RetryConfig: defaultRetryConfig()})
 	assert.True(t, diags.HasError())
 }
 
@@ -323,7 +323,7 @@ func TestUnitResourceHostDelete_Success(t *testing.T) {
 		"name": "x",
 	})
 	d.SetId("host-id")
-	diags := resourceHostDelete(context.Background(), d, c)
+	diags := resourceHostDelete(context.Background(), d, &providerMeta{Client: c, RetryConfig: defaultRetryConfig()})
 	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
 }
 
@@ -336,6 +336,6 @@ func TestUnitResourceHostDelete_Error(t *testing.T) {
 		"name": "x",
 	})
 	d.SetId("host-id")
-	diags := resourceHostDelete(context.Background(), d, c)
+	diags := resourceHostDelete(context.Background(), d, &providerMeta{Client: c, RetryConfig: defaultRetryConfig()})
 	assert.True(t, diags.HasError())
 }

--- a/cloudconnexa/resource_location_context.go
+++ b/cloudconnexa/resource_location_context.go
@@ -132,10 +132,13 @@ func defaultCheckConfig() *schema.Resource {
 
 // resourceLocationContextCreate creates a new Location Context in CloudConnexa.
 func resourceLocationContextCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	dr := resourceDataToLocationContext(d)
-	response, err := c.LocationContexts.Create(dr)
+	response, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.LocationContext, error) {
+		return c.LocationContexts.Create(dr)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -145,10 +148,13 @@ func resourceLocationContextCreate(ctx context.Context, d *schema.ResourceData, 
 
 // resourceLocationContextRead retrieves a Location Context from CloudConnexa.
 func resourceLocationContextRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := d.Id()
-	lc, err := c.LocationContexts.Get(id)
+	lc, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.LocationContext, error) {
+		return c.LocationContexts.Get(id)
+	})
 	if err != nil {
 		return append(diags, diag.Errorf("Failed to get location context with ID: %s, %s", id, err)...)
 	}
@@ -162,10 +168,13 @@ func resourceLocationContextRead(ctx context.Context, d *schema.ResourceData, m 
 
 // resourceLocationContextUpdate updates an existing Location Context in CloudConnexa.
 func resourceLocationContextUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	lc := resourceDataToLocationContext(d)
-	_, err := c.LocationContexts.Update(d.Id(), lc)
+	_, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.LocationContext, error) {
+		return c.LocationContexts.Update(d.Id(), lc)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -174,10 +183,13 @@ func resourceLocationContextUpdate(ctx context.Context, d *schema.ResourceData, 
 
 // resourceLocationContextDelete removes a Location Context from CloudConnexa.
 func resourceLocationContextDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	routeId := d.Id()
-	err := c.LocationContexts.Delete(routeId)
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.LocationContexts.Delete(routeId)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}

--- a/cloudconnexa/resource_network.go
+++ b/cloudconnexa/resource_network.go
@@ -76,7 +76,8 @@ func resourceNetwork() *schema.Resource {
 
 // resourceNetworkCreate creates a new network
 func resourceNetworkCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	n := cloudconnexa.Network{
 		Name:              d.Get("name").(string),
@@ -86,7 +87,9 @@ func resourceNetworkCreate(ctx context.Context, d *schema.ResourceData, m interf
 		TunnelingProtocol: d.Get("tunneling_protocol").(string),
 		GatewaysIDs:       gatewaysIdsFromResource(d),
 	}
-	network, err := c.Networks.Create(n)
+	network, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.Network, error) {
+		return c.Networks.Create(n)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -96,10 +99,13 @@ func resourceNetworkCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 // resourceNetworkRead reads the state of a network
 func resourceNetworkRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := d.Id()
-	network, err := c.Networks.Get(id)
+	network, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.Network, error) {
+		return c.Networks.Get(id)
+	})
 	if err != nil {
 		return append(diags, diag.Errorf("Failed to get network with ID: %s, %s", id, err)...)
 	}
@@ -119,7 +125,8 @@ func resourceNetworkRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 // resourceNetworkUpdate updates an existing network
 func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 
 	_, newName := d.GetChange("name")
@@ -127,14 +134,16 @@ func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, m interf
 	_, newEgress := d.GetChange("egress")
 	_, newAccess := d.GetChange("internet_access")
 	_, tunnelingProtocol := d.GetChange("tunneling_protocol")
-	err := c.Networks.Update(cloudconnexa.Network{
-		ID:                d.Id(),
-		Name:              newName.(string),
-		Description:       newDescription.(string),
-		Egress:            newEgress.(bool),
-		InternetAccess:    newAccess.(string),
-		TunnelingProtocol: tunnelingProtocol.(string),
-		GatewaysIDs:       gatewaysIdsFromResource(d),
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.Networks.Update(cloudconnexa.Network{
+			ID:                d.Id(),
+			Name:              newName.(string),
+			Description:       newDescription.(string),
+			Egress:            newEgress.(bool),
+			InternetAccess:    newAccess.(string),
+			TunnelingProtocol: tunnelingProtocol.(string),
+			GatewaysIDs:       gatewaysIdsFromResource(d),
+		})
 	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
@@ -144,10 +153,13 @@ func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, m interf
 
 // resourceNetworkDelete deletes a network
 func resourceNetworkDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	networkId := d.Id()
-	err := c.Networks.Delete(networkId)
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.Networks.Delete(networkId)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}

--- a/cloudconnexa/resource_network_application.go
+++ b/cloudconnexa/resource_network_application.go
@@ -60,9 +60,12 @@ func resourceNetworkApplication() *schema.Resource {
 
 // resourceNetworkApplicationUpdate handles updates to an existing network application
 func resourceNetworkApplicationUpdate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 
-	_, err := c.NetworkApplications.Update(data.Id(), resourceDataToNetworkApplication(data))
+	_, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.NetworkApplicationResponse, error) {
+		return c.NetworkApplications.Update(data.Id(), resourceDataToNetworkApplication(data))
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -122,10 +125,13 @@ func resourceNetworkApplicationConfig() *schema.Resource {
 
 // resourceNetworkApplicationRead retrieves and sets the state of a network application
 func resourceNetworkApplicationRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := data.Id()
-	application, err := c.NetworkApplications.Get(id)
+	application, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.NetworkApplicationResponse, error) {
+		return c.NetworkApplications.Get(id)
+	})
 	if err != nil {
 		return append(diags, diag.Errorf("Failed to get network application with ID: %s, %s", id, err)...)
 	}
@@ -139,9 +145,12 @@ func resourceNetworkApplicationRead(ctx context.Context, data *schema.ResourceDa
 
 // resourceNetworkApplicationDelete handles the deletion of a network application
 func resourceNetworkApplicationDelete(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
-	err := c.NetworkApplications.Delete(data.Id())
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.NetworkApplications.Delete(data.Id())
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -150,10 +159,13 @@ func resourceNetworkApplicationDelete(ctx context.Context, data *schema.Resource
 
 // resourceNetworkApplicationCreate handles the creation of a new network application
 func resourceNetworkApplicationCreate(ctx context.Context, data *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	client := meta.Client
 
 	application := resourceDataToNetworkApplication(data)
-	createdApplication, err := client.NetworkApplications.Create(application)
+	createdApplication, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.NetworkApplicationResponse, error) {
+		return client.NetworkApplications.Create(application)
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/cloudconnexa/resource_network_connector.go
+++ b/cloudconnexa/resource_network_connector.go
@@ -244,7 +244,8 @@ func ipSecConfigSchema() *schema.Resource {
 
 // resourceNetworkConnectorUpdate updates an existing network connector
 func resourceNetworkConnectorUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 
 	// Handle status change (suspend/activate)
@@ -252,11 +253,11 @@ func resourceNetworkConnectorUpdate(ctx context.Context, d *schema.ResourceData,
 		_, newStatus := d.GetChange("status")
 		switch newStatus.(string) {
 		case "SUSPENDED":
-			if err := c.NetworkConnectors.Suspend(d.Id()); err != nil {
+			if err := withRetryNoBody(ctx, meta.RetryConfig, func() error { return c.NetworkConnectors.Suspend(d.Id()) }); err != nil {
 				return append(diags, diag.FromErr(err)...)
 			}
 		case "ACTIVE":
-			if err := c.NetworkConnectors.Activate(d.Id()); err != nil {
+			if err := withRetryNoBody(ctx, meta.RetryConfig, func() error { return c.NetworkConnectors.Activate(d.Id()) }); err != nil {
 				return append(diags, diag.FromErr(err)...)
 			}
 		}
@@ -265,12 +266,16 @@ func resourceNetworkConnectorUpdate(ctx context.Context, d *schema.ResourceData,
 	// Handle other field changes
 	if d.HasChanges("name", "description", "vpn_region_id", "ipsec_config") {
 		connector := resourceDataToNetworkConnector(d)
-		_, err := c.NetworkConnectors.Update(connector)
+		_, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.NetworkConnector, error) {
+			return c.NetworkConnectors.Update(connector)
+		})
 		if err != nil {
 			return append(diags, diag.FromErr(err)...)
 		}
 		if connector.IPSecConfig != nil {
-			err := c.NetworkConnectors.StartIPsec(connector.ID)
+			err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+				return c.NetworkConnectors.StartIPsec(connector.ID)
+			})
 			if err != nil {
 				return append(diags, diag.FromErr(err)...)
 			}
@@ -282,21 +287,28 @@ func resourceNetworkConnectorUpdate(ctx context.Context, d *schema.ResourceData,
 
 // resourceNetworkConnectorCreate creates a new network connector
 func resourceNetworkConnectorCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	connector := resourceDataToNetworkConnector(d)
-	conn, err := c.NetworkConnectors.Create(connector, connector.NetworkItemID)
+	conn, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.NetworkConnector, error) {
+		return c.NetworkConnectors.Create(connector, connector.NetworkItemID)
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	d.SetId(conn.ID)
 	if conn.TunnelingProtocol == "OPENVPN" {
-		profile, err := c.NetworkConnectors.GetProfile(conn.ID)
+		profile, err := withRetry(ctx, meta.RetryConfig, func() (string, error) {
+			return c.NetworkConnectors.GetProfile(conn.ID)
+		})
 		if err != nil {
 			return append(diags, diag.FromErr(err)...)
 		}
 		d.Set("profile", profile)
-		token, err := c.NetworkConnectors.GetToken(conn.ID)
+		token, err := withRetry(ctx, meta.RetryConfig, func() (string, error) {
+			return c.NetworkConnectors.GetToken(conn.ID)
+		})
 		if err != nil {
 			return append(diags, diag.FromErr(err)...)
 		}
@@ -304,7 +316,9 @@ func resourceNetworkConnectorCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if conn.IPSecConfig != nil {
-		err := c.NetworkConnectors.StartIPsec(conn.ID)
+		err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+			return c.NetworkConnectors.StartIPsec(conn.ID)
+		})
 		if err != nil {
 			return append(diags, diag.FromErr(err)...)
 		}
@@ -319,22 +333,29 @@ func resourceNetworkConnectorCreate(ctx context.Context, d *schema.ResourceData,
 
 // resourceNetworkConnectorRead reads the state of a network connector
 func resourceNetworkConnectorRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := d.Id()
-	connector, err := c.NetworkConnectors.GetByID(id)
+	connector, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.NetworkConnector, error) {
+		return c.NetworkConnectors.GetByID(id)
+	})
 	if err != nil {
 		return append(diags, diag.Errorf("Failed to get network connector with ID: %s, %s", id, err)...)
 	}
 	setNetworkConnectorData(d, connector)
 
 	if connector.TunnelingProtocol == "OPENVPN" {
-		token, err := c.NetworkConnectors.GetToken(connector.ID)
+		token, err := withRetry(ctx, meta.RetryConfig, func() (string, error) {
+			return c.NetworkConnectors.GetToken(connector.ID)
+		})
 		if err != nil {
 			return append(diags, diag.FromErr(err)...)
 		}
 		d.Set("token", token)
-		profile, err := c.NetworkConnectors.GetProfile(connector.ID)
+		profile, err := withRetry(ctx, meta.RetryConfig, func() (string, error) {
+			return c.NetworkConnectors.GetProfile(connector.ID)
+		})
 		if err != nil {
 			return append(diags, diag.FromErr(err)...)
 		}
@@ -345,9 +366,12 @@ func resourceNetworkConnectorRead(ctx context.Context, d *schema.ResourceData, m
 
 // resourceNetworkConnectorDelete deletes a network connector
 func resourceNetworkConnectorDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
-	err := c.NetworkConnectors.Delete(d.Id(), d.Get("network_id").(string))
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.NetworkConnectors.Delete(d.Id(), d.Get("network_id").(string))
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}

--- a/cloudconnexa/resource_network_ip_service.go
+++ b/cloudconnexa/resource_network_ip_service.go
@@ -69,9 +69,12 @@ func resourceNetworkIPService() *schema.Resource {
 
 // resourceNetworkIpServiceUpdate updates an existing network IP service
 func resourceNetworkIpServiceUpdate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 
-	_, err := c.NetworkIPServices.Update(data.Id(), resourceDataToNetworkIpService(data))
+	_, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.NetworkIPServiceResponse, error) {
+		return c.NetworkIPServices.Update(data.Id(), resourceDataToNetworkIpService(data))
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -130,10 +133,13 @@ func customNetworkIpServiceTypesConfig() map[string]*schema.Schema {
 
 // resourceNetworkIpServiceRead retrieves a network IP service by ID
 func resourceNetworkIpServiceRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := data.Id()
-	service, err := c.NetworkIPServices.Get(id)
+	service, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.NetworkIPServiceResponse, error) {
+		return c.NetworkIPServices.Get(id)
+	})
 	if err != nil {
 		return append(diags, diag.Errorf("Failed to get network IP service with ID: %s, %s", id, err)...)
 	}
@@ -158,9 +164,12 @@ func setNetworkIpServiceResourceData(data *schema.ResourceData, service *cloudco
 
 // resourceNetworkIpServiceDelete deletes a network IP service
 func resourceNetworkIpServiceDelete(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
-	err := c.NetworkIPServices.Delete(data.Id())
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.NetworkIPServices.Delete(data.Id())
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -212,10 +221,13 @@ func flattenNetworkIpServiceRoutes(routes []*cloudconnexa.Route) []string {
 
 // resourceNetworkIpServiceCreate creates a new network IP service
 func resourceNetworkIpServiceCreate(ctx context.Context, data *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	client := meta.Client
 
 	service := resourceDataToNetworkIpService(data)
-	createdService, err := client.NetworkIPServices.Create(service)
+	createdService, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.NetworkIPServiceResponse, error) {
+		return client.NetworkIPServices.Create(service)
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/cloudconnexa/resource_route.go
+++ b/cloudconnexa/resource_route.go
@@ -65,7 +65,8 @@ func resourceRoute() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	networkItemId := d.Get("network_item_id").(string)
 	routeType := d.Get("type").(string)
@@ -76,7 +77,9 @@ func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, m interfac
 		Subnet:      routeSubnet,
 		Description: descriptionValue,
 	}
-	route, err := c.Routes.Create(networkItemId, r)
+	route, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.Route, error) {
+		return c.Routes.Create(networkItemId, r)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -98,10 +101,13 @@ func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, m interfac
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func resourceRouteRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := d.Id()
-	r, err := c.Routes.Get(id)
+	r, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.Route, error) {
+		return c.Routes.Get(id)
+	})
 	if err != nil {
 		return append(diags, diag.Errorf("Failed to get route with ID: %s, %s", id, err)...)
 	}
@@ -129,7 +135,8 @@ func resourceRouteRead(ctx context.Context, d *schema.ResourceData, m interface{
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	if !d.HasChanges("description", "subnet") {
 		return diags
@@ -143,7 +150,9 @@ func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 		Subnet:      subnet.(string),
 	}
 
-	err := c.Routes.Update(r)
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.Routes.Update(r)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -161,10 +170,13 @@ func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred during the operation
 func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	routeId := d.Id()
-	err := c.Routes.Delete(routeId)
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.Routes.Delete(routeId)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}

--- a/cloudconnexa/resource_route_test.go
+++ b/cloudconnexa/resource_route_test.go
@@ -63,7 +63,7 @@ func TestAccCloudConnexaRoute_basic(t *testing.T) {
 
 // testAccCheckCloudConnexaRouteDestroy verifies that the route has been destroyed
 func testAccCheckCloudConnexaRouteDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*cloudconnexa.Client)
+	client := testAccProvider.Meta().(*providerMeta).Client
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cloudconnexa_route" {
 			continue
@@ -92,7 +92,7 @@ func testAccCheckCloudConnexaRouteExists(n string, routeID *string) resource.Tes
 			return errors.New("no ID is set")
 		}
 
-		client := testAccProvider.Meta().(*cloudconnexa.Client)
+		client := testAccProvider.Meta().(*providerMeta).Client
 		_, err := client.Routes.Get(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/cloudconnexa/resource_settings.go
+++ b/cloudconnexa/resource_settings.go
@@ -227,7 +227,8 @@ func subnetSchema() *schema.Resource {
 
 // resourceSettingsUpdate handles the creation and update of CloudConnexa settings
 func resourceSettingsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 
 	if d.HasChange("allow_trusted_devices") {
@@ -423,7 +424,8 @@ func resourceSettingsUpdate(ctx context.Context, d *schema.ResourceData, m inter
 // and updates the Terraform state with the current values.
 // All API calls are unconditional to ensure proper import functionality.
 func resourceSettingsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 
 	allowTrustedDevices, err := c.Settings.GetTrustedDevicesAllowed()

--- a/cloudconnexa/resource_user.go
+++ b/cloudconnexa/resource_user.go
@@ -121,7 +121,8 @@ func resourceUser() *schema.Resource {
 
 // resourceUserCreate creates a new CloudConnexa user
 func resourceUserCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	username := d.Get("username").(string)
 	email := d.Get("email").(string)
@@ -155,7 +156,9 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, m interface
 		Devices:           devices,
 		Role:              role,
 	}
-	user, err := c.Users.Create(u)
+	user, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.User, error) {
+		return c.Users.Create(u)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -165,10 +168,13 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 // resourceUserRead retrieves information about an existing CloudConnexa user
 func resourceUserRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := d.Id()
-	u, err := c.Users.Get(id)
+	u, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.User, error) {
+		return c.Users.Get(id)
+	})
 
 	if err != nil {
 		return append(diags, diag.Errorf("Failed to get user with ID: %s, %s", id, err)...)
@@ -205,7 +211,8 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, m interface{}
 
 // resourceUserUpdate updates an existing CloudConnexa user's information
 func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 
 	// Handle status change (suspend/activate)
@@ -213,11 +220,11 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m interface
 		_, newStatus := d.GetChange("status")
 		switch newStatus.(string) {
 		case "SUSPENDED":
-			if err := c.Users.Suspend(d.Id()); err != nil {
+			if err := withRetryNoBody(ctx, meta.RetryConfig, func() error { return c.Users.Suspend(d.Id()) }); err != nil {
 				return append(diags, diag.FromErr(err)...)
 			}
 		case "ACTIVE":
-			if err := c.Users.Activate(d.Id()); err != nil {
+			if err := withRetryNoBody(ctx, meta.RetryConfig, func() error { return c.Users.Activate(d.Id()) }); err != nil {
 				return append(diags, diag.FromErr(err)...)
 			}
 		}
@@ -225,7 +232,9 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m interface
 
 	// Handle other field changes
 	if d.HasChanges("first_name", "last_name", "group_id", "email", "role", "secondary_groups_ids") {
-		u, err := c.Users.Get(d.Id())
+		u, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.User, error) {
+			return c.Users.Get(d.Id())
+		})
 		if err != nil {
 			return append(diags, diag.FromErr(err)...)
 		}
@@ -238,15 +247,17 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m interface
 		_, secondaryGroupsIds := d.GetChange("secondary_groups_ids")
 		status := u.Status
 
-		err = c.Users.Update(cloudconnexa.User{
-			ID:                d.Id(),
-			Email:             email.(string),
-			FirstName:         firstName.(string),
-			LastName:          lastName.(string),
-			GroupID:           groupId.(string),
-			SecondaryGroupIDs: toStrings(secondaryGroupsIds.([]interface{})),
-			Role:              role.(string),
-			Status:            status,
+		err = withRetryNoBody(ctx, meta.RetryConfig, func() error {
+			return c.Users.Update(cloudconnexa.User{
+				ID:                d.Id(),
+				Email:             email.(string),
+				FirstName:         firstName.(string),
+				LastName:          lastName.(string),
+				GroupID:           groupId.(string),
+				SecondaryGroupIDs: toStrings(secondaryGroupsIds.([]interface{})),
+				Role:              role.(string),
+				Status:            status,
+			})
 		})
 
 		if err != nil {
@@ -259,10 +270,13 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m interface
 
 // resourceUserDelete removes an existing CloudConnexa user
 func resourceUserDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	userId := d.Id()
-	err := c.Users.Delete(userId)
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.Users.Delete(userId)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}

--- a/cloudconnexa/resource_user_group.go
+++ b/cloudconnexa/resource_user_group.go
@@ -123,11 +123,14 @@ func tunnelBypassSchema() *schema.Resource {
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred
 func resourceUserGroupUpdate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	ug := resourceDataToUserGroup(data)
 
-	userGroup, err := c.UserGroups.Update(data.Id(), ug)
+	userGroup, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.UserGroup, error) {
+		return c.UserGroups.Update(data.Id(), ug)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -241,9 +244,12 @@ func updateUserGroupData(data *schema.ResourceData, userGroup *cloudconnexa.User
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred
 func resourceUserGroupDelete(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
-	err := c.UserGroups.Delete(data.Id())
+	err := withRetryNoBody(ctx, meta.RetryConfig, func() error {
+		return c.UserGroups.Delete(data.Id())
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
@@ -262,10 +268,13 @@ func resourceUserGroupDelete(ctx context.Context, data *schema.ResourceData, i i
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred
 func resourceUserGroupRead(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
-	c := i.(*cloudconnexa.Client)
+	meta := i.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	id := data.Id()
-	userGroup, err := c.UserGroups.Get(id)
+	userGroup, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.UserGroup, error) {
+		return c.UserGroups.Get(id)
+	})
 	if err != nil {
 		return append(diags, diag.Errorf("Failed to get user group with ID: %s, %s", id, err)...)
 	}
@@ -289,11 +298,14 @@ func resourceUserGroupRead(ctx context.Context, data *schema.ResourceData, i int
 // Returns:
 //   - diag.Diagnostics: Diagnostics containing any errors that occurred
 func resourceUserGroupCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*cloudconnexa.Client)
+	meta := m.(*providerMeta)
+	c := meta.Client
 	var diags diag.Diagnostics
 	ug := resourceDataToUserGroup(d)
 
-	userGroup, err := c.UserGroups.Create(ug)
+	userGroup, err := withRetry(ctx, meta.RetryConfig, func() (*cloudconnexa.UserGroup, error) {
+		return c.UserGroups.Create(ug)
+	})
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}

--- a/cloudconnexa/resource_user_group_test.go
+++ b/cloudconnexa/resource_user_group_test.go
@@ -69,7 +69,7 @@ func TestAccCloudConnexaUserGroup_basic(t *testing.T) {
 // Returns:
 //   - error: An error if the user group still exists or if there was an error checking its existence
 func testAccCheckCloudConnexaUserGroupDestroy(s *terraform.State) error {
-	c := testAccProvider.Meta().(*cloudconnexa.Client)
+	c := testAccProvider.Meta().(*providerMeta).Client
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cloudconnexa_user_group" {
 			continue
@@ -104,7 +104,7 @@ func testAccCheckCloudConnexaUserGroupExists(rn string) resource.TestCheckFunc {
 			return errors.New("no ID is set")
 		}
 
-		c := testAccProvider.Meta().(*cloudconnexa.Client)
+		c := testAccProvider.Meta().(*providerMeta).Client
 		_, err := c.UserGroups.Get(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/cloudconnexa/resource_user_test.go
+++ b/cloudconnexa/resource_user_test.go
@@ -71,7 +71,7 @@ func TestAccCloudConnexaUser_basic(t *testing.T) {
 // Returns:
 //   - error: An error if the user still exists or if there was an error checking its existence
 func testAccCheckCloudConnexaUserDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*cloudconnexa.Client)
+	client := testAccProvider.Meta().(*providerMeta).Client
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "cloudconnexa_user" {
 			continue
@@ -107,7 +107,7 @@ func testAccCheckCloudConnexaUserExists(n string, teamID *string) resource.TestC
 			return errors.New("no ID is set")
 		}
 
-		client := testAccProvider.Meta().(*cloudconnexa.Client)
+		client := testAccProvider.Meta().(*providerMeta).Client
 		_, err := client.Users.Get(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/cloudconnexa/retry.go
+++ b/cloudconnexa/retry.go
@@ -1,0 +1,106 @@
+package cloudconnexa
+
+import (
+	"context"
+	"errors"
+	"math"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/openvpn/cloudconnexa-go-client/v2/cloudconnexa"
+)
+
+// retryConfig holds configuration for the retry wrapper.
+type retryConfig struct {
+	MaxRetries   int
+	BaseDelay    time.Duration
+	MaxDelay     time.Duration
+	JitterFactor float64
+}
+
+// defaultRetryConfig returns sensible defaults for rate-limit retry.
+func defaultRetryConfig() retryConfig {
+	return retryConfig{
+		MaxRetries:   5,
+		BaseDelay:    1 * time.Second,
+		MaxDelay:     30 * time.Second,
+		JitterFactor: 0.2,
+	}
+}
+
+// isRetryable returns true if the error represents a transient failure that
+// should be retried (HTTP 429 Too Many Requests or 503 Service Unavailable).
+func isRetryable(err error) bool {
+	var apiErr *cloudconnexa.ErrClientResponse
+	if errors.As(err, &apiErr) {
+		code := apiErr.StatusCode()
+		return code == http.StatusTooManyRequests || code == http.StatusServiceUnavailable
+	}
+	return false
+}
+
+// backoffDelay calculates the delay for a given attempt using exponential
+// backoff with jitter, capped at cfg.MaxDelay.
+func backoffDelay(cfg retryConfig, attempt int) time.Duration {
+	delay := float64(cfg.BaseDelay) * math.Pow(2, float64(attempt))
+	if delay > float64(cfg.MaxDelay) {
+		delay = float64(cfg.MaxDelay)
+	}
+	// Apply jitter: delay ± jitterFactor*delay
+	jitter := (rand.Float64()*2 - 1) * cfg.JitterFactor * delay
+	delay += jitter
+	if delay < 0 {
+		delay = 0
+	}
+	return time.Duration(delay)
+}
+
+// withRetry executes fn and retries on retryable errors with exponential backoff.
+// It respects context cancellation.
+func withRetry[T any](ctx context.Context, cfg retryConfig, fn func() (T, error)) (T, error) {
+	var zero T
+	result, err := fn()
+	if err == nil {
+		return result, nil
+	}
+	if !isRetryable(err) {
+		return zero, err
+	}
+
+	for attempt := 0; attempt < cfg.MaxRetries; attempt++ {
+		delay := backoffDelay(cfg, attempt)
+		tflog.Warn(ctx, "retrying after rate limit or transient error",
+			map[string]interface{}{
+				"attempt":   attempt + 1,
+				"max":       cfg.MaxRetries,
+				"delay_ms":  delay.Milliseconds(),
+				"error_msg": err.Error(),
+			})
+
+		select {
+		case <-ctx.Done():
+			return zero, ctx.Err()
+		case <-time.After(delay):
+		}
+
+		result, err = fn()
+		if err == nil {
+			return result, nil
+		}
+		if !isRetryable(err) {
+			return zero, err
+		}
+	}
+	return zero, err
+}
+
+// withRetryNoBody executes fn (which returns only an error) and retries on
+// retryable errors with exponential backoff. Used for Update/Delete operations.
+func withRetryNoBody(ctx context.Context, cfg retryConfig, fn func() error) error {
+	_, err := withRetry(ctx, cfg, func() (struct{}, error) {
+		return struct{}{}, fn()
+	})
+	return err
+}

--- a/cloudconnexa/retry_test.go
+++ b/cloudconnexa/retry_test.go
@@ -1,0 +1,318 @@
+package cloudconnexa
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openvpn/cloudconnexa-go-client/v2/cloudconnexa"
+	"github.com/stretchr/testify/require"
+)
+
+// newRetryTestClient creates a client pointing at a test server.
+func newRetryTestClient(t *testing.T, handler http.Handler) *cloudconnexa.Client {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/oauth/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"unit-test-token"}`))
+	})
+	mux.Handle("/", handler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	c, err := cloudconnexa.NewClientWithOptions(server.URL, "test-id", "test-secret", &cloudconnexa.ClientOptions{
+		AllowInsecureHTTP: true,
+	})
+	require.NoError(t, err)
+	return c
+}
+
+// makeAPIError triggers a real SDK error with the given status code.
+func makeAPIError(t *testing.T, statusCode int) error {
+	t.Helper()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(`{"error":"test"}`))
+	})
+	c := newRetryTestClient(t, handler)
+	_, err := c.Hosts.Get("nonexistent")
+	require.Error(t, err)
+	return err
+}
+
+func TestUnit_isRetryable_429(t *testing.T) {
+	err := makeAPIError(t, http.StatusTooManyRequests)
+	if !isRetryable(err) {
+		t.Error("expected 429 to be retryable")
+	}
+}
+
+func TestUnit_isRetryable_503(t *testing.T) {
+	err := makeAPIError(t, http.StatusServiceUnavailable)
+	if !isRetryable(err) {
+		t.Error("expected 503 to be retryable")
+	}
+}
+
+func TestUnit_isRetryable_400(t *testing.T) {
+	err := makeAPIError(t, http.StatusBadRequest)
+	if isRetryable(err) {
+		t.Error("expected 400 to NOT be retryable")
+	}
+}
+
+func TestUnit_isRetryable_404(t *testing.T) {
+	err := makeAPIError(t, http.StatusNotFound)
+	if isRetryable(err) {
+		t.Error("expected 404 to NOT be retryable")
+	}
+}
+
+func TestUnit_isRetryable_GenericError(t *testing.T) {
+	err := errors.New("connection reset")
+	if isRetryable(err) {
+		t.Error("expected generic error to NOT be retryable")
+	}
+}
+
+func TestUnit_backoffDelay_ExponentialGrowth(t *testing.T) {
+	cfg := retryConfig{
+		MaxRetries:   5,
+		BaseDelay:    1 * time.Second,
+		MaxDelay:     30 * time.Second,
+		JitterFactor: 0,
+	}
+
+	expected := []time.Duration{
+		1 * time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+	}
+
+	for attempt, want := range expected {
+		got := backoffDelay(cfg, attempt)
+		if got != want {
+			t.Errorf("attempt %d: got %v, want %v", attempt, got, want)
+		}
+	}
+}
+
+func TestUnit_backoffDelay_CappedAtMaxDelay(t *testing.T) {
+	cfg := retryConfig{
+		MaxRetries:   10,
+		BaseDelay:    1 * time.Second,
+		MaxDelay:     5 * time.Second,
+		JitterFactor: 0,
+	}
+
+	got := backoffDelay(cfg, 5)
+	if got != 5*time.Second {
+		t.Errorf("expected delay capped at 5s, got %v", got)
+	}
+}
+
+func TestUnit_backoffDelay_WithJitter(t *testing.T) {
+	cfg := retryConfig{
+		MaxRetries:   5,
+		BaseDelay:    1 * time.Second,
+		MaxDelay:     30 * time.Second,
+		JitterFactor: 0.2,
+	}
+
+	for i := 0; i < 100; i++ {
+		got := backoffDelay(cfg, 0)
+		if got < 800*time.Millisecond || got > 1200*time.Millisecond {
+			t.Errorf("attempt 0 with jitter: got %v, expected [800ms, 1200ms]", got)
+		}
+	}
+}
+
+func TestUnit_withRetry_SuccessOnFirstCall(t *testing.T) {
+	cfg := defaultRetryConfig()
+	ctx := context.Background()
+
+	calls := 0
+	result, err := withRetry(ctx, cfg, func() (string, error) {
+		calls++
+		return "ok", nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "ok", result)
+	require.Equal(t, 1, calls)
+}
+
+func TestUnit_withRetry_RetriesOn429ThenSucceeds(t *testing.T) {
+	var callCount int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"host-1","name":"test","description":"","connectors":[]}`))
+	})
+	c := newRetryTestClient(t, handler)
+
+	cfg := retryConfig{
+		MaxRetries:   5,
+		BaseDelay:    1 * time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+		JitterFactor: 0,
+	}
+	ctx := context.Background()
+
+	host, err := withRetry(ctx, cfg, func() (*cloudconnexa.Host, error) {
+		return c.Hosts.Get("host-1")
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, host)
+	require.Equal(t, "host-1", host.ID)
+	require.Equal(t, int32(3), atomic.LoadInt32(&callCount))
+}
+
+func TestUnit_withRetry_ExhaustsRetries(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+	})
+	c := newRetryTestClient(t, handler)
+
+	cfg := retryConfig{
+		MaxRetries:   2,
+		BaseDelay:    1 * time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+		JitterFactor: 0,
+	}
+	ctx := context.Background()
+
+	var callCount int32
+	_, err := withRetry(ctx, cfg, func() (*cloudconnexa.Host, error) {
+		atomic.AddInt32(&callCount, 1)
+		return c.Hosts.Get("host-1")
+	})
+
+	require.Error(t, err)
+	require.Equal(t, int32(3), atomic.LoadInt32(&callCount))
+}
+
+func TestUnit_withRetry_NonRetryableErrorReturnsImmediately(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"bad request"}`))
+	})
+	c := newRetryTestClient(t, handler)
+
+	cfg := retryConfig{
+		MaxRetries:   5,
+		BaseDelay:    1 * time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+		JitterFactor: 0,
+	}
+	ctx := context.Background()
+
+	var callCount int32
+	_, err := withRetry(ctx, cfg, func() (*cloudconnexa.Host, error) {
+		atomic.AddInt32(&callCount, 1)
+		return c.Hosts.Get("host-1")
+	})
+
+	require.Error(t, err)
+	require.Equal(t, int32(1), atomic.LoadInt32(&callCount))
+}
+
+func TestUnit_withRetry_ContextCancellation(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+	})
+	c := newRetryTestClient(t, handler)
+
+	cfg := retryConfig{
+		MaxRetries:   10,
+		BaseDelay:    100 * time.Millisecond,
+		MaxDelay:     1 * time.Second,
+		JitterFactor: 0,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := withRetry(ctx, cfg, func() (*cloudconnexa.Host, error) {
+		return c.Hosts.Get("host-1")
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestUnit_withRetryNoBody_Success(t *testing.T) {
+	var callCount int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		if n < 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"rate limited"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	c := newRetryTestClient(t, handler)
+
+	cfg := retryConfig{
+		MaxRetries:   3,
+		BaseDelay:    1 * time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+		JitterFactor: 0,
+	}
+	ctx := context.Background()
+
+	err := withRetryNoBody(ctx, cfg, func() error {
+		return c.Hosts.Delete("host-1")
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, int32(2), atomic.LoadInt32(&callCount))
+}
+
+func TestUnit_withRetry_503ThenSucceeds(t *testing.T) {
+	var callCount int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"service unavailable"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"host-1","name":"test","description":"","connectors":[]}`))
+	})
+	c := newRetryTestClient(t, handler)
+
+	cfg := retryConfig{
+		MaxRetries:   3,
+		BaseDelay:    1 * time.Millisecond,
+		MaxDelay:     10 * time.Millisecond,
+		JitterFactor: 0,
+	}
+	ctx := context.Background()
+
+	host, err := withRetry(ctx, cfg, func() (*cloudconnexa.Host, error) {
+		return c.Hosts.Get("host-1")
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, host)
+	require.Equal(t, "host-1", host.ID)
+	require.Equal(t, int32(2), atomic.LoadInt32(&callCount))
+}


### PR DESCRIPTION
## Summary

Adds automatic retry with exponential backoff for HTTP 429 (Too Many Requests) and 503 (Service Unavailable) responses across all resources and data sources.

## Problem

When running Terraform with parallelism > 1 against the CloudConnexa API, users frequently hit rate limits (HTTP 429). The provider previously had no mechanism to handle this, requiring users to reduce parallelism to `-parallelism=1` which dramatically increases apply times.

## Solution

### Provider-level retry wrapper

- New `retry.go` with generic `withRetry[T]()` and `withRetryNoBody()` functions
- Exponential backoff: 1s base delay, 2x multiplier, capped at 30s, ±20% jitter
- Retries on HTTP 429 (Too Many Requests) and 503 (Service Unavailable)
- Respects context cancellation
- Logs retries at WARN level via `tflog` with attempt count, delay, and error details

### New provider attribute

```hcl
provider "cloudconnexa" {
  client_id     = var.client_id
  client_secret = var.client_secret
  base_url      = var.base_url
  max_retries   = 10  # optional, default 5
}