### PR TITLE
Bump version to v1.2.6 and document tag-only release flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,3 +57,5 @@ Two styles coexist in `cloudconnexa/`:
 ## Releases
 
 Tag-driven (`v*`) via `.github/workflows/release.yml` → GoReleaser. Cross-builds darwin/linux/windows/freebsd × amd64/386/arm/arm64, signs checksums with GPG, and publishes a **draft** GitHub release for manual review before going live. The `version` constant in `cloudconnexa/provider.go` is the user-agent string sent to the API — bump it when cutting a release.
+
+**Release only by pushing a tag — never create or publish the GitHub release manually in the UI.** GoReleaser owns release creation: it makes a *draft* release and uploads the signed assets (zips + `SHA256SUMS` + `.sig` + manifest) to it, and you then Publish that draft. If a *published* (non-draft) release already exists on the tag when the workflow runs, GoReleaser cannot attach its assets to it (GitHub immutable published releases), so the run goes green but the release ships with zero assets and the Terraform Registry never ingests it. This is exactly what broke v1.2.5.

--- a/cloudconnexa/provider.go
+++ b/cloudconnexa/provider.go
@@ -21,7 +21,7 @@ const ClientSecretEnvVar = "CLOUDCONNEXA_CLIENT_SECRET"
 var cloudIDPattern = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
 
 // version represents the current version of the Terraform provider
-var version = "v1.2.4"
+var version = "v1.2.6"
 
 // Token represents the authentication token structure returned by the CloudConnexa API
 type Token struct {


### PR DESCRIPTION
v1.2.5 shipped with zero assets because a published GitHub release was created manually before GoReleaser ran, leaving it unable to attach the signed artifacts, so the Terraform Registry never ingested it. Cut v1.2.6 via the proper GoReleaser flow and document that releases must be created by pushing a tag only.